### PR TITLE
removing concept specification from config.jsons

### DIFF
--- a/adaptive_n_back/config.json
+++ b/adaptive_n_back/config.json
@@ -2,8 +2,6 @@
     {
         "name": "Adaptive N-Back",
         "tag": "adaptive_n_back",
-        "cognitive_atlas_concept_id":"trm_4aae62e4ad209",
-        "cognitive_atlas_concept":"cognitive control",
         "cognitive_atlas_task_id": "",
         "contributors": [
                          "Ian Eisenberg",

--- a/ant/config.json
+++ b/ant/config.json
@@ -7,8 +7,6 @@
                  "jspsych-ANT-practice.js"
               ],
         "tag": "ant",
-        "cognitive_atlas_concept_id":"trm_4aae62e4ad209",
-        "cognitive_atlas_concept":"cognitive control",
         "cognitive_atlas_task_id": "",
         "contributors": [
                          "Ian Eisenberg",

--- a/antisaccade/config.json
+++ b/antisaccade/config.json
@@ -6,8 +6,6 @@
                 "style.css"
                ],
         "tag": "antisaccade",
-        "cognitive_atlas_concept_id":"trm_4aae62e4ad209",
-        "cognitive_atlas_concept":"cognitive control",
         "cognitive_atlas_task_id": "",
         "contributors": [
                          "Ian Eisenberg",

--- a/art/config.json
+++ b/art/config.json
@@ -7,8 +7,6 @@
                 "static/js/jspsych/plugins/jspsych-call-function.js"
                ],
         "tag": "art",
-        "cognitive_atlas_concept_id":"trm_4aae62e4ad209",
-        "cognitive_atlas_concept":"cognitive control",
         "cognitive_atlas_task_id": "",
         "contributors": [
                          "Ian Eisenberg",

--- a/ax_cpt/config.json
+++ b/ax_cpt/config.json
@@ -6,8 +6,6 @@
                 "style.css"
                ],
         "tag": "ax_cpt",
-        "cognitive_atlas_concept_id":"trm_4aae62e4ad209",
-        "cognitive_atlas_concept":"cognitive control",
         "cognitive_atlas_task_id": "",
         "contributors": [
                          "Ian Eisenberg",

--- a/choice_rt/config.json
+++ b/choice_rt/config.json
@@ -6,8 +6,6 @@
                 "style.css"
                ],
         "tag": "choice_rt",
-        "cognitive_atlas_concept_id":"trm_4aae62e4ad209",
-        "cognitive_atlas_concept":"cognitive control",
         "cognitive_atlas_task_id": "",
         "contributors": [
                          "Ian Eisenberg",

--- a/directed_forgetting/config.json
+++ b/directed_forgetting/config.json
@@ -6,8 +6,6 @@
                  "style.css"
                ],
         "tag": "directed_forgetting",
-        "cognitive_atlas_concept_id":"trm_4aae62e4ad209",
-        "cognitive_atlas_concept":"cognitive control",
         "cognitive_atlas_task_id": "",
         "contributors": [
                          "Jamie Li",

--- a/discount_titrate/config.json
+++ b/discount_titrate/config.json
@@ -6,8 +6,6 @@
                  "style.css"
                ],
         "tag": "discount_titrate",
-        "cognitive_atlas_concept_id":"trm_4aae62e4ad209",
-        "cognitive_atlas_concept":"cognitive control",
         "cognitive_atlas_task_id": "",
         "contributors": [
                          "Zeynep Enkavi",

--- a/dospert_eb/config.json
+++ b/dospert_eb/config.json
@@ -6,8 +6,6 @@
                  "style.css"
                ],
         "tag": "dospert_eb",
-        "cognitive_atlas_concept_id":"trm_4aae62e4ad209",
-        "cognitive_atlas_concept":"cognitive control",
         "cognitive_atlas_task_id": "",
         "contributors": [
                          "Zeynep Enkavi",

--- a/dospert_rp/config.json
+++ b/dospert_rp/config.json
@@ -6,8 +6,6 @@
                  "style.css"
                ],
         "tag": "dospert_rp",
-        "cognitive_atlas_concept_id":"trm_4aae62e4ad209",
-        "cognitive_atlas_concept":"cognitive control",
         "cognitive_atlas_task_id": "",
         "contributors": [
                          "Zeynep Enkavi",

--- a/dospert_rt/config.json
+++ b/dospert_rt/config.json
@@ -6,8 +6,6 @@
                  "style.css"
                ],
         "tag": "dospert_rt",
-        "cognitive_atlas_concept_id":"trm_4aae62e4ad209",
-        "cognitive_atlas_concept":"cognitive control",
         "cognitive_atlas_task_id": "",
         "contributors": [
                          "Zeynep Enkavi",

--- a/dpx/config.json
+++ b/dpx/config.json
@@ -6,8 +6,6 @@
                  "style.css"
                ],
         "tag": "dpx",
-        "cognitive_atlas_concept_id":"trm_4aae62e4ad209",
-        "cognitive_atlas_concept":"cognitive control",
         "cognitive_atlas_task_id": "",
         "contributors": [
                          "Ian Eisenberg",

--- a/flanker/config.json
+++ b/flanker/config.json
@@ -6,8 +6,6 @@
                 "style.css"
                ],
         "tag": "flanker",
-        "cognitive_atlas_concept_id":"trm_4aae62e4ad209",
-        "cognitive_atlas_concept":"cognitive control",
         "cognitive_atlas_task_id": "",
         "contributors": [
                          "Ian Eisenberg",

--- a/go_nogo/config.json
+++ b/go_nogo/config.json
@@ -6,8 +6,6 @@
                 "style.css"
                ],
         "tag": "go_nogo",
-        "cognitive_atlas_concept_id":"trm_4aae62e4ad209",
-        "cognitive_atlas_concept":"cognitive control",
         "cognitive_atlas_task_id": "",
         "contributors": [
                          "Ian Eisenberg",

--- a/holt_laury/config.json
+++ b/holt_laury/config.json
@@ -6,8 +6,6 @@
                  "style.css"
                ],
         "tag": "holt_laury",
-        "cognitive_atlas_concept_id":"trm_4aae62e4ad209",
-        "cognitive_atlas_concept":"cognitive control",
         "cognitive_atlas_task_id": "",
         "contributors": [
                          "Zeynep Enkavi",

--- a/ided/config.json
+++ b/ided/config.json
@@ -7,8 +7,6 @@
                  "static/js/jspsych/plugins/jspsych-call-function.js"
                ], 
         "tag": "ided",
-        "cognitive_atlas_concept_id":"trm_4aae62e4ad209",
-        "cognitive_atlas_concept":"cognitive control",
         "cognitive_atlas_task_id": "",
         "contributors": [
                          "Ian Eisenberg",

--- a/image_monitoring/config.json
+++ b/image_monitoring/config.json
@@ -7,8 +7,6 @@
                 "static/js/jspsych/plugins/jspsych-call-function.js"
                ],
         "tag": "image_monitoring",
-        "cognitive_atlas_concept_id":"trm_4aae62e4ad209",
-        "cognitive_atlas_concept":"cognitive control",
         "cognitive_atlas_task_id": "",
         "contributors": [
                          "Ian Eisenberg",

--- a/keep_track/config.json
+++ b/keep_track/config.json
@@ -6,8 +6,6 @@
                 "style.css"
                 ],
         "tag": "keep_track",
-        "cognitive_atlas_concept_id":"trm_4aae62e4ad209",
-        "cognitive_atlas_concept":"cognitive control",
         "cognitive_atlas_task_id": "",
         "contributors": [
                          "Ian Eisenberg",

--- a/kirby/config.json
+++ b/kirby/config.json
@@ -6,8 +6,6 @@
                  "style.css"
                ],
         "tag": "kirby",
-        "cognitive_atlas_concept_id":"trm_4aae62e4ad209",
-        "cognitive_atlas_concept":"cognitive control",
         "cognitive_atlas_task_id": "",
         "contributors": [
                          "Zeynep Enkavi",

--- a/letter_memory/config.json
+++ b/letter_memory/config.json
@@ -5,8 +5,6 @@
                 "experiment.js"
                ],
         "tag": "letter_memory",
-        "cognitive_atlas_concept_id":"trm_4aae62e4ad209",
-        "cognitive_atlas_concept":"cognitive control",
         "cognitive_atlas_task_id": "",
         "contributors": [
                          "Ian Eisenberg",

--- a/local_global/config.json
+++ b/local_global/config.json
@@ -6,8 +6,6 @@
                 "style.css"
                ],
         "tag": "local_global",
-        "cognitive_atlas_concept_id":"trm_4aae62e4ad209",
-        "cognitive_atlas_concept":"cognitive control",
         "cognitive_atlas_task_id": "",
         "contributors": [
                          "Ian Eisenberg",

--- a/multiplication/config.json
+++ b/multiplication/config.json
@@ -5,8 +5,6 @@
                  "experiment.js"
                ],
         "tag": "multiplication",
-        "cognitive_atlas_concept_id":"trm_4aae62e4ad209",
-        "cognitive_atlas_concept":"cognitive control",
         "cognitive_atlas_task_id": "",
         "contributors": [
                          "Ian Eisenberg",

--- a/multisource/config.json
+++ b/multisource/config.json
@@ -6,8 +6,6 @@
                "style.css"
               ],
         "tag": "multisource",
-        "cognitive_atlas_concept_id":"trm_4aae62e4ad209",
-        "cognitive_atlas_concept":"cognitive control",
         "cognitive_atlas_task_id": "",
         "contributors": [
                          "Ian Eisenberg",

--- a/n_back/config.json
+++ b/n_back/config.json
@@ -5,8 +5,6 @@
                  "experiment.js"
                ],
         "tag": "n_back",
-        "cognitive_atlas_concept_id":"trm_4aae62e4ad209",
-        "cognitive_atlas_concept":"cognitive control",
         "cognitive_atlas_task_id": "",
         "contributors": [
                          "Ian Eisenberg",

--- a/number_letter/config.json
+++ b/number_letter/config.json
@@ -6,8 +6,6 @@
                  "style.css"
                ],
         "tag": "number_letter",
-        "cognitive_atlas_concept_id":"trm_4aae62e4ad209",
-        "cognitive_atlas_concept":"cognitive control",
         "cognitive_atlas_task_id": "",
         "contributors": [
                          "Ian Eisenberg",

--- a/plus_minus/config.json
+++ b/plus_minus/config.json
@@ -5,8 +5,6 @@
                 "experiment.js"
                ],
         "tag": "plus_minus",
-        "cognitive_atlas_concept_id":"trm_4aae62e4ad209",
-        "cognitive_atlas_concept":"cognitive control",
         "cognitive_atlas_task_id": "",
         "contributors": [
                          "Ian Eisenberg",

--- a/probabilistic_selection/config.json
+++ b/probabilistic_selection/config.json
@@ -6,8 +6,6 @@
                  "style.css"
                ],
         "tag": "probabilistic_selection",
-        "cognitive_atlas_concept_id":"trm_4aae62e4ad209",
-        "cognitive_atlas_concept":"cognitive control",
         "cognitive_atlas_task_id": "",
         "contributors": [
                          "Jamie Li",

--- a/recent_probes/config.json
+++ b/recent_probes/config.json
@@ -6,8 +6,6 @@
                  "style.css"
                ],
         "tag": "recent_probes",
-        "cognitive_atlas_concept_id":"trm_4aae62e4ad209",
-        "cognitive_atlas_concept":"cognitive control",
         "cognitive_atlas_task_id": "",
         "contributors": [
                          "Jamie Li",

--- a/rng/config.json
+++ b/rng/config.json
@@ -7,8 +7,6 @@
                 "static/js/jspsych/custom_plugins/jspsych-multi-button.js"
                ],
         "tag": "rng",
-        "cognitive_atlas_concept_id":"trm_4aae62e4ad209",
-        "cognitive_atlas_concept":"cognitive control",
         "cognitive_atlas_task_id": "",
         "contributors": [
                          "Ian Eisenberg",

--- a/simon/config.json
+++ b/simon/config.json
@@ -6,8 +6,6 @@
                 "style.css"
                ],
         "tag": "simon",
-        "cognitive_atlas_concept_id":"trm_4aae62e4ad209",
-        "cognitive_atlas_concept":"cognitive control",
         "cognitive_atlas_task_id": "",
         "contributors": [
                          "Ian Eisenberg",

--- a/simple_rt/config.json
+++ b/simple_rt/config.json
@@ -6,8 +6,6 @@
                 "style.css"
                ],
         "tag": "simple_rt",
-        "cognitive_atlas_concept_id":"trm_4aae62e4ad209",
-        "cognitive_atlas_concept":"cognitive control",
         "cognitive_atlas_task_id": "",
         "contributors": [
                          "Ian Eisenberg",

--- a/stop_signal/config.json
+++ b/stop_signal/config.json
@@ -8,8 +8,6 @@
                 "static/js/jspsych/plugins/jspsych-call-function.js"
                ],
         "tag": "stop_signal",
-        "cognitive_atlas_concept_id":"trm_4aae62e4ad209",
-        "cognitive_atlas_concept":"cognitive control",
         "cognitive_atlas_task_id": "",
         "contributors": [
                          "Ian Eisenberg",

--- a/stroop/config.json
+++ b/stroop/config.json
@@ -6,8 +6,6 @@
                 "style.css"
                ],
         "tag": "stroop",
-        "cognitive_atlas_concept_id":"trm_4aae62e4ad209",
-        "cognitive_atlas_concept":"cognitive control",
         "cognitive_atlas_task_id": "",
         "contributors": [
                          "Ian Eisenberg",

--- a/threebytwo/config.json
+++ b/threebytwo/config.json
@@ -6,8 +6,6 @@
                  "style.css"
                ],
         "tag": "threebytwo",
-        "cognitive_atlas_concept_id":"trm_4aae62e4ad209",
-        "cognitive_atlas_concept":"cognitive control",
         "cognitive_atlas_task_id": "",
         "contributors": [
                          "Ian Eisenberg",

--- a/tone_monitoring/config.json
+++ b/tone_monitoring/config.json
@@ -8,8 +8,6 @@
 		 "static/js/jspsych/plugins/jspsych-call-function.js"
                ],
         "tag": "tone_monitoring",
-        "cognitive_atlas_concept_id":"trm_4aae62e4ad209",
-        "cognitive_atlas_concept":"cognitive control",
         "cognitive_atlas_task_id": "",
         "contributors": [
                          "Ian Eisenberg",

--- a/two_stage_decision/config.json
+++ b/two_stage_decision/config.json
@@ -2,8 +2,6 @@
     {
         "name": "Two-stage-decision-task",
         "tag": "two_stage_decision",
-        "cognitive_atlas_concept_id":"trm_4aae62e4ad209",
-        "cognitive_atlas_concept":"cognitive control",
         "cognitive_atlas_task_id": "",
         "contributors": [
                          "Ian Eisenberg",

--- a/volatile_bandit/config.json
+++ b/volatile_bandit/config.json
@@ -6,8 +6,6 @@
                 "style.css"
                ],
         "tag": "volatile_bandit",
-        "cognitive_atlas_concept_id":"trm_4aae62e4ad209",
-        "cognitive_atlas_concept":"cognitive control",
         "cognitive_atlas_task_id": "",
         "contributors": [
                          "Ian Eisenberg",


### PR DESCRIPTION
This will remove the specification of concept ids and names from the config.json. The reason for this is because the concepts are represented in the cognitive atlas, and linked by way of the tasks. Thus, all we need to do is specify the tasks, and this will be a requirement for tasks presented in the docker/django implementation. 

The expfactory-python tool will be updated shortly after this!