### PR TITLE
Update configs to include experiment variables

### DIFF
--- a/adaptive_n_back/config.json
+++ b/adaptive_n_back/config.json
@@ -10,13 +10,13 @@
                          "Vanessa Sochat",
                          "Russell Poldrack"
                         ], 
-        "lab": "Poldracklab",
         "run": [
                 "experiment.js",
                 "static/js/jspsych/plugins/jspsych-call-function.js"
                 ],
         "time":16,
-        "doi":"",
+        "performance_variable": "",
+        "rejection_variable": "",
         "reference": "http://www.sciencedirect.com/science/article/pii/S1053811905001424",
         "notes": "This task differs in that the subject only has to respond on target trials, rather than indicating whether the current trial is a match or not. Condition records the n for that block of trials. The second reference is not explicitly used.",
         "publish":"True"

--- a/ant/config.json
+++ b/ant/config.json
@@ -16,8 +16,8 @@
                          "Russell Poldrack"
                         ], 
         "time":20,
-        "lab": "Poldracklab",
-        "doi": "10.1162/089892902317361886",
+        "performance_variable": "",
+        "rejection_variable": "",
         "reference": "http://www.mitpressjournals.org/doi/pdf/10.1162/089892902317361886",
         "notes": "",
         "publish":"True"

--- a/antisaccade/config.json
+++ b/antisaccade/config.json
@@ -14,9 +14,9 @@
                          "Vanessa Sochat",
                          "Russell Poldrack"
                         ], 
-        "lab": "Poldracklab",
         "time":8,
-        "doi": "10.1006/cogp.1999.0734",
+        "performance_variable": "",
+        "rejection_variable": "",
         "reference": "http://www.sciencedirect.com/science/article/pii/S001002859990734X",
         "notes": "Condition indicates the location of the target stimulus",
         "publish":"True"

--- a/art/config.json
+++ b/art/config.json
@@ -17,8 +17,8 @@
                          "Russell Poldrack"
                         ], 
         "time":45,
-        "lab": "Poldracklab",
-        "doi": "",
+        "performance_variable": "",
+        "rejection_variable": "",
         "reference": "http://www.ncbi.nlm.nih.gov/pubmed/18194061",
         "notes": "",
         "publish":"True"

--- a/ax_cpt/config.json
+++ b/ax_cpt/config.json
@@ -14,9 +14,9 @@
                          "Vanessa Sochat",
                          "Russell Poldrack"
                         ], 
-        "lab": "Poldracklab",
         "time":20,
-        "doi": "",
+        "performance_variable": "",
+        "rejection_variable": "",
         "reference": "http://www.pnas.org/content/suppl/2009/04/20/0808187106.DCSupplemental/0808187106SI.pdf#nameddest=STXT",
         "notes": "Condition indicates cue/target trial type: AX, BX, AY, BY",
         "publish":"True"

--- a/choice_rt/config.json
+++ b/choice_rt/config.json
@@ -15,8 +15,8 @@
                          "Russell Poldrack"
                         ], 
         "time":4,
-        "lab": "Poldracklab",
-        "doi": "",
+        "performance_variable": "",
+        "rejection_variable": "",
         "reference": "http://www.sciencedirect.com/science/article/pii/0001691869900651",
         "notes": "",
         "publish":"True"

--- a/digit_span/config.json
+++ b/digit_span/config.json
@@ -17,9 +17,9 @@
                          "Vanessa Sochat",
                          "Russell Poldrack"
                         ], 
-        "lab": "Poldracklab",
         "time":5,
-        "doi": "",
+        "performance_variable": "",
+        "rejection_variable": "",
         "reference": "http://ajp.psychiatryonline.org/doi/pdf/10.1176/appi.ajp.157.2.275",
         "notes": "",
         "publish":"True"

--- a/directed_forgetting/config.json
+++ b/directed_forgetting/config.json
@@ -15,9 +15,9 @@
                          "Vanessa Sochat",
                          "Russell Poldrack"
                         ], 
-        "lab": "Poldracklab",
         "time":999,
-        "doi": "",
+        "performance_variable": "",
+        "rejection_variable": "",
         "reference": "http://www.ncbi.nlm.nih.gov/pmc/articles/PMC2206737/",
         "notes": "",
         "publish":"True"

--- a/discount_titrate/config.json
+++ b/discount_titrate/config.json
@@ -14,9 +14,9 @@
                          "Vanessa Sochat",
                          "Russell Poldrack"
                         ], 
-        "lab": "Poldracklab",
         "time":10,
-        "doi": "",
+        "performance_variable": "",
+        "rejection_variable": "",
         "reference": "http://www.nature.com/neuro/journal/v13/n5/extref/nn.2516-S1.pdf",
         "notes": "",
         "publish":"True"

--- a/dospert_eb/config.json
+++ b/dospert_eb/config.json
@@ -14,9 +14,9 @@
                          "Vanessa Sochat",
                          "Russell Poldrack"
                         ], 
-        "lab": "Poldracklab",
         "time":999,
-        "doi": "",
+        "performance_variable": "",
+        "rejection_variable": "",
         "reference": "https://sites.google.com/a/decisionsciences.columbia.edu/dospert",
         "notes": "",
         "publish":"True"

--- a/dospert_rp/config.json
+++ b/dospert_rp/config.json
@@ -14,9 +14,9 @@
                          "Vanessa Sochat",
                          "Russell Poldrack"
                         ], 
-        "lab": "Poldracklab",
         "time":999,
-        "doi": "",
+        "performance_variable": "",
+        "rejection_variable": "",
         "reference": "https://sites.google.com/a/decisionsciences.columbia.edu/dospert",
         "notes": "",
         "publish":"True"

--- a/dospert_rt/config.json
+++ b/dospert_rt/config.json
@@ -14,9 +14,9 @@
                          "Vanessa Sochat",
                          "Russell Poldrack"
                         ], 
-        "lab": "Poldracklab",
         "time":999,
-        "doi": "",
+        "performance_variable": "",
+        "rejection_variable": "",
         "reference": "https://sites.google.com/a/decisionsciences.columbia.edu/dospert",
         "notes": "",
         "publish":"True"

--- a/dpx/config.json
+++ b/dpx/config.json
@@ -14,9 +14,9 @@
                          "Vanessa Sochat",
                          "Russell Poldrack"
                         ], 
-        "lab": "Poldracklab",
         "time":15,
-        "doi": "",
+        "performance_variable": "",
+        "rejection_variable": "",
         "reference": "http://www.mitpressjournals.org/doi/pdf/10.1162/jocn_a_00709",
         "notes": "Condition indicates cue/target trial type: AX, BX, AY, BY",
         "publish":"True"

--- a/flanker/config.json
+++ b/flanker/config.json
@@ -14,9 +14,9 @@
                          "Vanessa Sochat",
                          "Russell Poldrack"
                         ], 
-        "lab": "Poldracklab",
         "time":6.5,
-        "doi": "",
+        "performance_variable": "",
+        "rejection_variable": "",
         "reference": "",
         "notes": "",
         "publish":"True"

--- a/go_nogo/config.json
+++ b/go_nogo/config.json
@@ -14,9 +14,9 @@
                          "Vanessa Sochat",
                          "Russell Poldrack"
                         ], 
-        "lab": "Poldracklab",
         "time":7,
-        "doi": "",
+        "performance_variable": "",
+        "rejection_variable": "",
         "reference": "http://www.sciencedirect.com/science/article/pii/0001691869900651",
         "notes": "",
         "publish":"True"

--- a/hierarchical_rule/config.json
+++ b/hierarchical_rule/config.json
@@ -14,9 +14,9 @@
                          "Vanessa Sochat",
                          "Russell Poldrack"
                         ], 
-        "lab": "Poldracklab",
         "time":5,
-        "doi": "",
+        "performance_variable": "",
+        "rejection_variable": "",
         "reference": "http://www.sciencedirect.com/science/article/pii/S0896627310001960",
         "publish":"True"
     

--- a/holt_laury/config.json
+++ b/holt_laury/config.json
@@ -14,9 +14,9 @@
                          "Vanessa Sochat",
                          "Russell Poldrack"
                         ], 
-        "lab": "Poldracklab",
         "time":999,
-        "doi": "",
+        "performance_variable": "",
+        "rejection_variable": "",
         "reference": "http://users.nber.org/~rosenbla/econ311-04/syllabus/holtlaury.pdf",
         "notes": "",
         "publish":"True"

--- a/ided/config.json
+++ b/ided/config.json
@@ -15,9 +15,9 @@
                          "Vanessa Sochat",
                          "Russell Poldrack"
                         ], 
-        "lab": "Poldracklab",
         "time":10,
-        "doi": "",
+        "performance_variable": "",
+        "rejection_variable": "",
         "reference": "http://www.sciencedirect.com/science/article/pii/0028393289901280",
         "notes": "Condition indicates stage in the IDED task",
         "publish":"True"

--- a/image_monitoring/config.json
+++ b/image_monitoring/config.json
@@ -15,9 +15,9 @@
                          "Vanessa Sochat",
                          "Russell Poldrack"
                         ], 
-        "lab": "Poldracklab",
         "time":6,
-        "doi": "",
+        "performance_variable": "",
+        "rejection_variable": "",
         "reference": "http://www.sciencedirect.com/science/article/pii/S001002859990734X",
         "notes": "condition indicates practice/test, trial_id indicates stimulus shown on each trial. Correct response is determined by repetitions since last response and is not calculated in experiment.js (calculate in post)",
         "publish":"True"

--- a/keep_track/config.json
+++ b/keep_track/config.json
@@ -14,9 +14,9 @@
                          "Vanessa Sochat",
                          "Russell Poldrack"
                         ], 
-        "lab": "Poldracklab",
         "time":6,
-        "doi": "",
+        "performance_variable": "",
+        "rejection_variable": "",
         "reference": "http://www.sciencedirect.com/science/article/pii/S001002859990734X",
         "notes": "Condition indicates difficulty as quantified by the 'target length': the number of categories the subject had to remember",
         "publish":"True"

--- a/kirby/config.json
+++ b/kirby/config.json
@@ -14,9 +14,9 @@
                          "Vanessa Sochat",
                          "Russell Poldrack"
                         ], 
-        "lab": "Poldracklab",
         "time":5,
-        "doi": "",
+        "performance_variable": "",
+        "rejection_variable": "",
         "reference": "http://link.springer.com/article/10.3758/BF03210748",
         "notes": "",
         "publish":"True"

--- a/letter_memory/config.json
+++ b/letter_memory/config.json
@@ -13,9 +13,9 @@
                          "Vanessa Sochat",
                          "Russell Poldrack"
                         ], 
-        "lab": "Poldracklab",
         "time":5,
-        "doi": "",
+        "performance_variable": "",
+        "rejection_variable": "",
         "reference": "http://www.sciencedirect.com/science/article/pii/S001002859990734X",
         "notes": "Condition records difficulty as quantified by the sequence length",
         "publish":"True"

--- a/local_global/config.json
+++ b/local_global/config.json
@@ -14,9 +14,9 @@
                          "Vanessa Sochat",
                          "Russell Poldrack"
                         ], 
-        "lab": "Poldracklab",
         "time":5,
-        "doi": "",
+        "performance_variable": "",
+        "rejection_variable": "",
         "reference": "http://www.sciencedirect.com/science/article/pii/S001002859990734X",
         "notes": "",
         "publish":"True"

--- a/multiplication/config.json
+++ b/multiplication/config.json
@@ -13,9 +13,9 @@
                          "Vanessa Sochat",
                          "Russell Poldrack"
                         ], 
-        "lab": "Poldracklab",
         "time":5,
-        "doi": "",
+        "performance_variable": "",
+        "rejection_variable": "",
         "reference": "",
         "notes": "",
         "publish":"True"

--- a/multisource/config.json
+++ b/multisource/config.json
@@ -14,9 +14,9 @@
                          "Vanessa Sochat",
                          "Russell Poldrack"
                         ], 
-        "lab": "Poldracklab",
         "time":7,
-        "doi": "",
+        "performance_variable": "",
+        "rejection_variable": "",
         "reference": "",
         "notes": "Condition records current block (practice/test control/interference), trial_id records stimulus ID (where the target is: left, middle or right) and whether the target is large or small",
         "publish":"True"

--- a/n_back/config.json
+++ b/n_back/config.json
@@ -13,9 +13,9 @@
                          "Vanessa Sochat",
                          "Russell Poldrack"
                         ], 
-        "lab": "Poldracklab",
         "time":16,
-        "doi": "",
+        "performance_variable": "",
+        "rejection_variable": "",
         "reference": "http://www.sciencedirect.com/science/article/pii/S1053811905001424",
         "notes": "This task differs in that the subject only has to respond on target trials, rather than indicating whether the current trial is  a match or not",
         "publish":"True"

--- a/number_letter/config.json
+++ b/number_letter/config.json
@@ -14,9 +14,9 @@
                          "Vanessa Sochat",
                          "Russell Poldrack"
                         ], 
-        "lab": "Poldracklab",
         "time":5,
-        "doi": "",
+        "performance_variable": "",
+        "rejection_variable": "",
         "reference": "http://www.sciencedirect.com/science/article/pii/S001002859990734X",
         "notes": "condition indicates block (which task, or rotateswitch block) and trial_id indicates stimulus position",
         "publish":"True"

--- a/plus_minus/config.json
+++ b/plus_minus/config.json
@@ -13,9 +13,9 @@
                          "Vanessa Sochat",
                          "Russell Poldrack"
                         ], 
-        "lab": "Poldracklab",
         "time":5,
-        "doi": "",
+        "performance_variable": "",
+        "rejection_variable": "",
         "reference": "http://www.sciencedirect.com/science/article/pii/S001002859990734X",
         "notes": "Condition indicates block task (add, subtract, alternate)",
         "publish":"True"

--- a/probabilistic_selection/config.json
+++ b/probabilistic_selection/config.json
@@ -15,9 +15,9 @@
                          "Vanessa Sochat",
                          "Russell Poldrack"
                         ], 
-        "lab": "Poldracklab",
         "time":999,
-        "doi": "",
+        "performance_variable": "",
+        "rejection_variable": "",
         "reference": "http://www.nature.com/neuro/journal/v14/n2/fig_tab/nn.2723_F3.html",
         "notes": "",
         "publish":"True"

--- a/recent_probes/config.json
+++ b/recent_probes/config.json
@@ -15,9 +15,9 @@
                          "Vanessa Sochat",
                          "Russell Poldrack"
                         ], 
-        "lab": "Poldracklab",
         "time":999,
-        "doi": "",
+        "performance_variable": "",
+        "rejection_variable": "",
         "reference": "http://www.ncbi.nlm.nih.gov/pmc/articles/PMC2206737/",
         "notes": "",
         "publish":"True"

--- a/rng/config.json
+++ b/rng/config.json
@@ -15,9 +15,9 @@
                          "Vanessa Sochat",
                          "Russell Poldrack"
                         ], 
-        "lab": "Poldracklab",
         "time":3,
-        "doi": "",
+        "performance_variable": "",
+        "rejection_variable": "",
         "reference": "http://www.sciencedirect.com/science/article/pii/S1053811905001424",
         "notes": "",
         "publish":"True"

--- a/simon/config.json
+++ b/simon/config.json
@@ -14,9 +14,9 @@
                          "Vanessa Sochat",
                          "Russell Poldrack"
                         ], 
-        "lab": "Poldracklab",
         "time":5,
-        "doi": "",
+        "performance_variable": "",
+        "rejection_variable": "",
         "reference": "http://link.springer.com/article/10.3758%2FBF03210959",
         "notes": "",
         "publish":"True"

--- a/simple_rt/config.json
+++ b/simple_rt/config.json
@@ -14,9 +14,9 @@
                          "Vanessa Sochat",
                          "Russell Poldrack"
                         ], 
-        "lab": "Poldracklab",
         "time":3.5,
-        "doi": "",
+        "performance_variable": "",
+        "rejection_variable": "",
         "reference": "http://www.sciencedirect.com/science/article/pii/0001691869900651",
         "notes": "",
         "publish":"True"

--- a/stop_signal/config.json
+++ b/stop_signal/config.json
@@ -16,9 +16,9 @@
                          "Vanessa Sochat",
                          "Russell Poldrack"
                         ], 
-        "lab": "Poldracklab",
         "time":30,
-        "doi": "",
+        "performance_variable": "",
+        "rejection_variable": "",
         "reference": "http://psycnet.apa.org/journals/xlm/37/2/392/",
         "notes": "Condition refers to whether the trial is practice or high_freq/low_freq (the two test conditions) as well as whether it was a go or SS trial",
         "publish":"True"

--- a/stroop/config.json
+++ b/stroop/config.json
@@ -14,9 +14,9 @@
                          "Vanessa Sochat",
                          "Russell Poldrack"
                         ], 
-        "lab": "Poldracklab",
         "time":5,
-        "doi": "",
+        "performance_variable": "",
+        "rejection_variable": "",
         "reference": "http://journals.plos.org/plosone/article?id=10.1371/journal.pone.0057410",
         "notes": "Conditions refers to congruency on each trial",
         "publish":"True"

--- a/test_task/config.json
+++ b/test_task/config.json
@@ -14,9 +14,9 @@
                          "Vanessa Sochat",
                          "Russell Poldrack"
                         ], 
-        "lab": "Poldracklab",
         "time":1,
-        "doi": "",
+        "performance_variable": "",
+        "rejection_variable": "",
         "reference": "http://www.sciencedirect.com/science/article/pii/0001691869900651",
         "notes": "",
         "publish":"True"

--- a/threebytwo/config.json
+++ b/threebytwo/config.json
@@ -14,9 +14,9 @@
                          "Vanessa Sochat",
                          "Russell Poldrack"
                         ], 
-        "lab": "Poldracklab",
         "time":24,
-        "doi": "",
+        "performance_variable": "",
+        "rejection_variable": "",
         "reference": "http://www.ncbi.nlm.nih.gov/pubmed/21299334",
         "notes": "",
         "publish":"True"

--- a/tone_monitoring/config.json
+++ b/tone_monitoring/config.json
@@ -16,9 +16,9 @@
                          "Vanessa Sochat",
                          "Russell Poldrack"
                         ], 
-        "lab": "Poldracklab",
         "time":6,
-        "doi": "",
+        "performance_variable": "",
+        "rejection_variable": "",
         "reference": "http://www.sciencedirect.com/science/article/pii/S001002859990734X",
         "notes": "condition indicates practice/test, trial_id indicates stimulus heard on each trial. Correct response is determined by repetitions since last response and is not calculated in this script (calculate in post)",
         "publish":"True"

--- a/two_stage_decision/config.json
+++ b/two_stage_decision/config.json
@@ -10,14 +10,14 @@
                          "Vanessa Sochat",
                          "Russell Poldrack"
                         ], 
-        "lab": "Poldracklab",
         "run": [
                 "experiment.js",
                 "style.css",
                 "static/js/jspsych/plugins/jspsych-call-function.js"
                ],
         "time":26,
-        "doi":"10.1016/j.neuron.2011.02.027",
+        "performance_variable": "",
+        "rejection_variable": "",
         "reference": "http://www.sciencedirect.com/science/article/pii/S0896627311001255",
         "notes": "Condition = ordered stims in stage 1 and stage 2 (so [0, 1] or [1, 0] for stage 1 and [2, 3], [4, 5] etc. for stage 2 and FB for the FB condition (1 for reward, 0 for no reward)",
         "publish":"True"

--- a/volatile_bandit/config.json
+++ b/volatile_bandit/config.json
@@ -14,9 +14,9 @@
                          "Vanessa Sochat",
                          "Russell Poldrack"
                         ], 
-        "lab": "Poldracklab",
         "time":18,
-        "doi": "",
+        "performance_variable": "",
+        "rejection_variable": "",
         "reference": "http://www.nature.com/neuro/journal/v10/n9/pdf/nn1954.pdf",
         "notes": "",
         "publish":"True"


### PR DESCRIPTION
I have also removed the "lab" and "doi" fields as these are not useful / are redundant. I am keeping reference for now until we have the change to migrate these into the Cognitive Atlas. We should not merge this PR until expfactory-python has been updated to not validate looking for those fields.