### PR TITLE
1) stop + cued task uses number, and the old version had it say in th…

### DIFF
--- a/stop_signal_with_cued_task_switching/experiment.js
+++ b/stop_signal_with_cued_task_switching/experiment.js
@@ -539,7 +539,7 @@ var instructions_block = {
     '</div>',
     
     '<div class = centerbox>' + 
-  		'<p class = block-text>On some trials, a star will appear around the letter.  The star will appear with, or shortly after the letter appears.</p>'+
+  		'<p class = block-text>On some trials, a star will appear around the number.  The star will appear with, or shortly after the number appears.</p>'+
   		
   		'<p class = block-text>If you see a star appear, please try your best to make no response on that trial.</p>'+
   	

--- a/stop_signal_with_directed_forgetting/experiment.js
+++ b/stop_signal_with_directed_forgetting/experiment.js
@@ -971,7 +971,7 @@ var practiceNode = {
 
 var testTrials = []
 testTrials.push(feedback_block)
-testTrials.push(attention_node)
+// testTrials.push(attention_node)
 for (i = 0; i < numTrialsPerBlock; i++) { 
 	testTrials.push(start_fixation_block) //500ms
 	testTrials.push(training_block) //2000


### PR DESCRIPTION
…e instructions letter -> fixed to number. 2) stop + DF has 10 blocks, thus needs 10 attention check questions; the old attention check plugin has only 7 questions -> remove attention check for now to stop task from breaking after 7 blocks.