### PR TITLE
add stop_signal__fmri fixation cross

### DIFF
--- a/stop_signal__fmri/style.css
+++ b/stop_signal__fmri/style.css
@@ -64,6 +64,16 @@
     margin: auto;  
 }
 
+.fixation {
+  text-align: center;
+  font-size: 150px;
+  position: relative;
+  top: 50%;
+  transform: translateY(-50%);
+  -webkit-transform: translateY(-50%);
+  color: white;
+ }
+
 .prompt_stim {
   height: 90px;
   margin: auto;


### PR DESCRIPTION
Changed stop_signal__fmri/style.css to make fixation cross white (visible against black background).