### PR TITLE
fix fmri blocking, cue control commas

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .script
 test.sh
 web/
+rest__fmri/Rest_v6.mp4

--- a/cue_control_food/experiment.js
+++ b/cue_control_food/experiment.js
@@ -464,8 +464,8 @@ var instructions_block = {
 	},
 	timing_response: -1,
 	text: '<div class = bigbox><div class = centerbox>'+
-			'<p class = block-text style="font-size:36px"><font color = "white">If the cue is, NOW, please think about the immediate consequences of consuming/using the item.</font></p>'+
-			'<p class = block-text style="font-size:36px"><font color = "white">If the cue is, LATER, please think about the long-term consequences of repeatedly consuming/using the item.</font></p>'+
+			'<p class = block-text style="font-size:36px"><font color = "white">If the cue is NOW, please think about the immediate consequences of consuming/using the item.</font></p>'+
+			'<p class = block-text style="font-size:36px"><font color = "white">If the cue is LATER, please think about the long-term consequences of repeatedly consuming/using the item.</font></p>'+
 			'<p class = block-text style="font-size:36px"><font color = "white">After, please indicate how much you currently want to consume/use the item.</font></p>'+
 			'<p class = block-text style="font-size:36px"><font color = "white">1 = very low , 5 = very high</font></p>'+
 			'<p class = block-text style="font-size:36px"><font color = "white">1 = thumb , 5 = pinky</font></p>'+		

--- a/cue_control_food__fmri/experiment.js
+++ b/cue_control_food__fmri/experiment.js
@@ -467,8 +467,8 @@ var instructions_block = {
 	},
 	timing_response: -1,
 	text: '<div class = bigbox><div class = centerbox>'+
-			'<p class = block-text style="font-size:36px"><font color = "white">If the cue is, NOW, please think about the immediate consequences of consuming/using the item.</font></p>'+
-			'<p class = block-text style="font-size:36px"><font color = "white">If the cue is, LATER, please think about the long-term consequences of repeatedly consuming/using the item.</font></p>'+
+			'<p class = block-text style="font-size:36px"><font color = "white">If the cue is NOW, please think about the immediate consequences of consuming/using the item.</font></p>'+
+			'<p class = block-text style="font-size:36px"><font color = "white">If the cue is LATER, please think about the long-term consequences of repeatedly consuming/using the item.</font></p>'+
 			'<p class = block-text style="font-size:36px"><font color = "white">After, please indicate how much you currently want to consume/use the item.</font></p>'+
 			'<p class = block-text style="font-size:36px"><font color = "white">1 = very low , 5 = very high</font></p>'+
 			'<p class = block-text style="font-size:36px"><font color = "white">1 = thumb , 5 = pinky</font></p>'+		

--- a/cue_control_food_practice/experiment.js
+++ b/cue_control_food_practice/experiment.js
@@ -384,8 +384,8 @@ var instructions_block = {
 	text: '<div class = bigbox><div class = centerbox>'+
 			'<p class = block-text><font color = "white">Each trial is composed of multiple parts.</font></p>'+
 			'<p class = block-text><font color = "white">In the first part, you will see a cue, either NOW or LATER followed by an item.  The cue will instruct you how to think about the item.</font></p>'+
-			'<p class = block-text><font color = "white">If you see the cue, NOW, please think about the immediate consequences of consuming/using the item.</font></p>'+
-			'<p class = block-text><font color = "white">If you see the cue, LATER, please think about the long-term consequences of repeatedly consuming/using the item.</font></p>'+
+			'<p class = block-text><font color = "white">If you see the cue NOW, please think about the immediate consequences of consuming/using the item.</font></p>'+
+			'<p class = block-text><font color = "white">If you see the cue LATER, please think about the long-term consequences of repeatedly consuming/using the item.</font></p>'+
 			'<p class = block-text><font color = "white">In the second part, you will rate the current item.  Please indicate how much you currently want to consume/use the item on the screen.</font></p>'+
 			'<p class = block-text><font color = "white">Press <strong>enter</strong> to continue.</font></p>'+		
 	

--- a/cue_control_smoking/experiment.js
+++ b/cue_control_smoking/experiment.js
@@ -461,8 +461,8 @@ var instructions_block = {
 	},
 	timing_response: -1,
 	text: '<div class = bigbox><div class = centerbox>'+
-			'<p class = block-text style="font-size:36px"><font color = "white">If the cue is, NOW, please think about the immediate consequences of consuming/using the item.</font></p>'+
-			'<p class = block-text style="font-size:36px"><font color = "white">If the cue is, LATER, please think about the long-term consequences of repeatedly consuming/using the item.</font></p>'+
+			'<p class = block-text style="font-size:36px"><font color = "white">If the cue is NOW, please think about the immediate consequences of consuming/using the item.</font></p>'+
+			'<p class = block-text style="font-size:36px"><font color = "white">If the cue is LATER, please think about the long-term consequences of repeatedly consuming/using the item.</font></p>'+
 			'<p class = block-text style="font-size:36px"><font color = "white">After, please indicate how much you currently want to consume/use the item.</font></p>'+
 			'<p class = block-text style="font-size:36px"><font color = "white">1 = very low , 5 = very high</font></p>'+
 			'<p class = block-text style="font-size:36px"><font color = "white">1 = thumb , 5 = pinky</font></p>'+		

--- a/cue_control_smoking__fmri/experiment.js
+++ b/cue_control_smoking__fmri/experiment.js
@@ -464,8 +464,8 @@ var instructions_block = {
 	},
 	timing_response: -1,
 	text: '<div class = bigbox><div class = centerbox>'+
-			'<p class = block-text style="font-size:36px"><font color = "white">If the cue is, NOW, please think about the immediate consequences of consuming/using the item.</font></p>'+
-			'<p class = block-text style="font-size:36px"><font color = "white">If the cue is, LATER, please think about the long-term consequences of repeatedly consuming/using the item.</font></p>'+
+			'<p class = block-text style="font-size:36px"><font color = "white">If the cue is NOW, please think about the immediate consequences of consuming/using the item.</font></p>'+
+			'<p class = block-text style="font-size:36px"><font color = "white">If the cue is LATER, please think about the long-term consequences of repeatedly consuming/using the item.</font></p>'+
 			'<p class = block-text style="font-size:36px"><font color = "white">After, please indicate how much you currently want to consume/use the item.</font></p>'+
 			'<p class = block-text style="font-size:36px"><font color = "white">1 = very low , 5 = very high</font></p>'+
 			'<p class = block-text style="font-size:36px"><font color = "white">1 = thumb , 5 = pinky</font></p>'+		

--- a/cue_control_smoking_practice/experiment.js
+++ b/cue_control_smoking_practice/experiment.js
@@ -383,8 +383,8 @@ var instructions_block = {
 	text: '<div class = bigbox><div class = centerbox>'+
 			'<p class = block-text><font color = "white">Each trial is composed of multiple parts.</font></p>'+
 			'<p class = block-text><font color = "white">In the first part, you will see a cue, either NOW or LATER followed by an item.  The cue will instruct you how to think about the item.</font></p>'+
-			'<p class = block-text><font color = "white">If you see the cue, NOW, please think about the immediate consequences of consuming/using the item.</font></p>'+
-			'<p class = block-text><font color = "white">If you see the cue, LATER, please think about the long-term consequences of repeatedly consuming/using the item.</font></p>'+
+			'<p class = block-text><font color = "white">If you see the cue NOW, please think about the immediate consequences of consuming/using the item.</font></p>'+
+			'<p class = block-text><font color = "white">If you see the cue LATER, please think about the long-term consequences of repeatedly consuming/using the item.</font></p>'+
 			'<p class = block-text><font color = "white">In the second part, you will rate the current item.  Please indicate how much you currently want to consume/use the item on the screen.</font></p>'+
 			'<p class = block-text><font color = "white">Press <strong>enter</strong> to continue.</font></p>'+		
 	

--- a/motor_selective_stop_signal__fmri/experiment.js
+++ b/motor_selective_stop_signal__fmri/experiment.js
@@ -579,7 +579,7 @@ for (i = 0; i < test_len; i++) {
 		}
 	}
 	motor_selective_stop_signal__fmri_experiment.push(stop_signal_block)
-	if ((i%test_block_len === 0) && (i>0)) {
+	if (((i+1)%test_block_len === 0) && (i>0)) {
 		motor_selective_stop_signal__fmri_experiment.push(rest_block)
 	}
 }

--- a/stop_signal__fmri/experiment.js
+++ b/stop_signal__fmri/experiment.js
@@ -480,7 +480,7 @@ for (i = 0; i < exp_len; i++) {
 		}
 	}
 	stop_signal__fmri_experiment.push(stop_signal_trial)
-	if ((i%42 === 0) && ( i > 0)) {
+	if (((i+1)%42 === 0) && ( i > 0)) {
 		stop_signal__fmri_experiment.push(rest_block)
 		stop_signal__fmri_experiment.push(start_test_block)
 	}


### PR DESCRIPTION
for stop_signal__fmri and motor_selective_stop_signal__fmri, changed block break up to [42, 42, 41] and blocks of 50 trials respectively.

For the cue control tasks, removed unnecessary commas  before the cues NOW and LATER in the instructions.