### PR TITLE
Revert "remove incorrect cognitive atlas ids from config files"

### DIFF
--- a/alcohol_drugs_survey__dartmouth_baseline/config.json
+++ b/alcohol_drugs_survey__dartmouth_baseline/config.json
@@ -1,49 +1,51 @@
 [
-  {
-    "name": "Alcohol Drugs Survey - Dartmouth Baseline",
-    "template": "jspsych",
-    "run": [
-      "static/js/jspsych/jspsych.js",
-      "static/js/jspsych/plugins/jspsych-call-function.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-text.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-instructions.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-attention-check.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-single-stim.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-categorize.js",
-      "static/js/jspsych/plugins/jspsych-survey-text.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-stop-signal.js",
-      "static/css/jspsych.css",
-      "static/css/default_style.css",
-      "style.css",
-      "experiment.js"
-    ],
-    "exp_id": "alcohol_drugs_survey__dartmouth_baseline",
-    "contributors": [
-      "Jamie Li",
-      "Ian Eisenberg",
-      "Patrick Bissett",
-      "Zeynep Enkavi",
-      "Sadiv Parikh",
-      "Russell Poldrack"
-    ],
-    "time": 30,
-    "reference": "http://psycnet.apa.org/journals/xlm/37/2/392/",
-    "notes": "Condition refers to whether the trial is practice or high_freq/low_freq (the two test conditions) as well as whether it was a go or SS trial",
-    "publish": "True",
-    "experiment_variables": [
-      {
-        "name": "credit_var",
-        "type": "credit",
-        "datatype": "boolean",
-        "description": "True if avg_rt > 200"
-      }
-    ],
-    "deployment_variables": {
-      "jspsych_init": {
-        "fullscreen": true,
-        "display_element": "getDisplayElement",
-        "on_trial_finish": "addID()"
-      }
-    }
-  }
+    {
+        "name": "Alcohol Drugs Survey - Dartmouth Baseline",
+        "template":"jspsych",
+        "run": [
+
+                "static/js/jspsych/jspsych.js",
+                "static/js/jspsych/plugins/jspsych-call-function.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-text.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-instructions.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-attention-check.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-single-stim.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-categorize.js",
+                "static/js/jspsych/plugins/jspsych-survey-text.js", 
+                "static/js/jspsych/poldrack_plugins/jspsych-stop-signal.js",
+                "static/css/jspsych.css",
+                "static/css/default_style.css",
+                "style.css",
+                "experiment.js"
+                
+                
+               ],
+        "exp_id": "alcohol_drugs_survey__dartmouth_baseline",
+        "cognitive_atlas_task_id": "tsk_4a57abb949e1a",
+        "contributors": [
+                         "Jamie Li",
+                         "Ian Eisenberg",
+                         "Patrick Bissett",
+                         "Zeynep Enkavi",
+                         "Sadiv Parikh",
+                         "Russell Poldrack"
+                        ], 
+        "time":30,
+        "reference": "http://psycnet.apa.org/journals/xlm/37/2/392/",
+        "notes": "Condition refers to whether the trial is practice or high_freq/low_freq (the two test conditions) as well as whether it was a go or SS trial",
+        "publish":"True",
+        "experiment_variables": [{
+                                 "name":"credit_var",
+                                 "type":"credit",
+                                 "datatype": "boolean",
+                                 "description":"True if avg_rt > 200"
+                                  }],
+        "deployment_variables":{"jspsych_init":
+                                        {"fullscreen": true,
+                                        "display_element": "getDisplayElement",
+                                        "on_trial_finish": "addID()"}
+                       			} 
+    
+   }
 ]
+

--- a/alcohol_drugs_survey__dartmouth_followup/config.json
+++ b/alcohol_drugs_survey__dartmouth_followup/config.json
@@ -1,49 +1,51 @@
 [
-  {
-    "name": "Alcohol Drugs Survey - Dartmouth Follow-up",
-    "template": "jspsych",
-    "run": [
-      "static/js/jspsych/jspsych.js",
-      "static/js/jspsych/plugins/jspsych-call-function.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-text.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-instructions.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-attention-check.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-single-stim.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-categorize.js",
-      "static/js/jspsych/plugins/jspsych-survey-text.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-stop-signal.js",
-      "static/css/jspsych.css",
-      "static/css/default_style.css",
-      "style.css",
-      "experiment.js"
-    ],
-    "exp_id": "alcohol_drugs_survey__dartmouth_followup",
-    "contributors": [
-      "Jamie Li",
-      "Ian Eisenberg",
-      "Patrick Bissett",
-      "Zeynep Enkavi",
-      "Sadiv Parikh",
-      "Russell Poldrack"
-    ],
-    "time": 30,
-    "reference": "http://psycnet.apa.org/journals/xlm/37/2/392/",
-    "notes": "Condition refers to whether the trial is practice or high_freq/low_freq (the two test conditions) as well as whether it was a go or SS trial",
-    "publish": "True",
-    "experiment_variables": [
-      {
-        "name": "credit_var",
-        "type": "credit",
-        "datatype": "boolean",
-        "description": "True if avg_rt > 200"
-      }
-    ],
-    "deployment_variables": {
-      "jspsych_init": {
-        "fullscreen": true,
-        "display_element": "getDisplayElement",
-        "on_trial_finish": "addID()"
-      }
-    }
-  }
+    {
+        "name": "Alcohol Drugs Survey - Dartmouth Follow-up",
+        "template":"jspsych",
+        "run": [
+
+                "static/js/jspsych/jspsych.js",
+                "static/js/jspsych/plugins/jspsych-call-function.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-text.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-instructions.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-attention-check.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-single-stim.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-categorize.js",
+                "static/js/jspsych/plugins/jspsych-survey-text.js", 
+                "static/js/jspsych/poldrack_plugins/jspsych-stop-signal.js",
+                "static/css/jspsych.css",
+                "static/css/default_style.css",
+                "style.css",
+                "experiment.js"
+                
+                
+               ],
+        "exp_id": "alcohol_drugs_survey__dartmouth_followup",
+        "cognitive_atlas_task_id": "tsk_4a57abb949e1a",
+        "contributors": [
+                         "Jamie Li",
+                         "Ian Eisenberg",
+                         "Patrick Bissett",
+                         "Zeynep Enkavi",
+                         "Sadiv Parikh",
+                         "Russell Poldrack"
+                        ], 
+        "time":30,
+        "reference": "http://psycnet.apa.org/journals/xlm/37/2/392/",
+        "notes": "Condition refers to whether the trial is practice or high_freq/low_freq (the two test conditions) as well as whether it was a go or SS trial",
+        "publish":"True",
+        "experiment_variables": [{
+                                 "name":"credit_var",
+                                 "type":"credit",
+                                 "datatype": "boolean",
+                                 "description":"True if avg_rt > 200"
+                                  }],
+        "deployment_variables":{"jspsych_init":
+                                        {"fullscreen": true,
+                                        "display_element": "getDisplayElement",
+                                        "on_trial_finish": "addID()"}
+                       			} 
+    
+   }
 ]
+

--- a/alcohol_drugs_survey__stanford_baseline/config.json
+++ b/alcohol_drugs_survey__stanford_baseline/config.json
@@ -1,49 +1,51 @@
 [
-  {
-    "name": "Alcohol Drugs Survey - Stanford Baseline",
-    "template": "jspsych",
-    "run": [
-      "static/js/jspsych/jspsych.js",
-      "static/js/jspsych/plugins/jspsych-call-function.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-text.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-instructions.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-attention-check.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-single-stim.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-categorize.js",
-      "static/js/jspsych/plugins/jspsych-survey-text.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-stop-signal.js",
-      "static/css/jspsych.css",
-      "static/css/default_style.css",
-      "style.css",
-      "experiment.js"
-    ],
-    "exp_id": "alcohol_drugs_survey__stanford_baseline",
-    "contributors": [
-      "Jamie Li",
-      "Ian Eisenberg",
-      "Patrick Bissett",
-      "Zeynep Enkavi",
-      "Sadiv Parikh",
-      "Russell Poldrack"
-    ],
-    "time": 30,
-    "reference": "http://psycnet.apa.org/journals/xlm/37/2/392/",
-    "notes": "Condition refers to whether the trial is practice or high_freq/low_freq (the two test conditions) as well as whether it was a go or SS trial",
-    "publish": "True",
-    "experiment_variables": [
-      {
-        "name": "credit_var",
-        "type": "credit",
-        "datatype": "boolean",
-        "description": "True if avg_rt > 200"
-      }
-    ],
-    "deployment_variables": {
-      "jspsych_init": {
-        "fullscreen": true,
-        "display_element": "getDisplayElement",
-        "on_trial_finish": "addID()"
-      }
-    }
-  }
+    {
+        "name": "Alcohol Drugs Survey - Stanford Baseline",
+        "template":"jspsych",
+        "run": [
+
+                "static/js/jspsych/jspsych.js",
+                "static/js/jspsych/plugins/jspsych-call-function.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-text.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-instructions.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-attention-check.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-single-stim.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-categorize.js",
+                "static/js/jspsych/plugins/jspsych-survey-text.js", 
+                "static/js/jspsych/poldrack_plugins/jspsych-stop-signal.js",
+                "static/css/jspsych.css",
+                "static/css/default_style.css",
+                "style.css",
+                "experiment.js"
+                
+                
+               ],
+        "exp_id": "alcohol_drugs_survey__stanford_baseline",
+        "cognitive_atlas_task_id": "tsk_4a57abb949e1a",
+        "contributors": [
+                         "Jamie Li",
+                         "Ian Eisenberg",
+                         "Patrick Bissett",
+                         "Zeynep Enkavi",
+                         "Sadiv Parikh",
+                         "Russell Poldrack"
+                        ], 
+        "time":30,
+        "reference": "http://psycnet.apa.org/journals/xlm/37/2/392/",
+        "notes": "Condition refers to whether the trial is practice or high_freq/low_freq (the two test conditions) as well as whether it was a go or SS trial",
+        "publish":"True",
+        "experiment_variables": [{
+                                 "name":"credit_var",
+                                 "type":"credit",
+                                 "datatype": "boolean",
+                                 "description":"True if avg_rt > 200"
+                                  }],
+        "deployment_variables":{"jspsych_init":
+                                        {"fullscreen": true,
+                                        "display_element": "getDisplayElement",
+                                        "on_trial_finish": "addID()"}
+                       			} 
+    
+   }
 ]
+

--- a/alcohol_drugs_survey__stanford_followup/config.json
+++ b/alcohol_drugs_survey__stanford_followup/config.json
@@ -1,49 +1,51 @@
 [
-  {
-    "name": "Alcohol Drugs Survey - Stanford Follow-up",
-    "template": "jspsych",
-    "run": [
-      "static/js/jspsych/jspsych.js",
-      "static/js/jspsych/plugins/jspsych-call-function.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-text.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-instructions.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-attention-check.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-single-stim.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-categorize.js",
-      "static/js/jspsych/plugins/jspsych-survey-text.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-stop-signal.js",
-      "static/css/jspsych.css",
-      "static/css/default_style.css",
-      "style.css",
-      "experiment.js"
-    ],
-    "exp_id": "alcohol_drugs_survey__stanford_followup",
-    "contributors": [
-      "Jamie Li",
-      "Ian Eisenberg",
-      "Patrick Bissett",
-      "Zeynep Enkavi",
-      "Sadiv Parikh",
-      "Russell Poldrack"
-    ],
-    "time": 30,
-    "reference": "http://psycnet.apa.org/journals/xlm/37/2/392/",
-    "notes": "Condition refers to whether the trial is practice or high_freq/low_freq (the two test conditions) as well as whether it was a go or SS trial",
-    "publish": "True",
-    "experiment_variables": [
-      {
-        "name": "credit_var",
-        "type": "credit",
-        "datatype": "boolean",
-        "description": "True if avg_rt > 200"
-      }
-    ],
-    "deployment_variables": {
-      "jspsych_init": {
-        "fullscreen": true,
-        "display_element": "getDisplayElement",
-        "on_trial_finish": "addID()"
-      }
-    }
-  }
+    {
+        "name": "Alcohol Drugs Survey - Stanford Follow-up",
+        "template":"jspsych",
+        "run": [
+
+                "static/js/jspsych/jspsych.js",
+                "static/js/jspsych/plugins/jspsych-call-function.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-text.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-instructions.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-attention-check.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-single-stim.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-categorize.js",
+                "static/js/jspsych/plugins/jspsych-survey-text.js", 
+                "static/js/jspsych/poldrack_plugins/jspsych-stop-signal.js",
+                "static/css/jspsych.css",
+                "static/css/default_style.css",
+                "style.css",
+                "experiment.js"
+                
+                
+               ],
+        "exp_id": "alcohol_drugs_survey__stanford_followup",
+        "cognitive_atlas_task_id": "tsk_4a57abb949e1a",
+        "contributors": [
+                         "Jamie Li",
+                         "Ian Eisenberg",
+                         "Patrick Bissett",
+                         "Zeynep Enkavi",
+                         "Sadiv Parikh",
+                         "Russell Poldrack"
+                        ], 
+        "time":30,
+        "reference": "http://psycnet.apa.org/journals/xlm/37/2/392/",
+        "notes": "Condition refers to whether the trial is practice or high_freq/low_freq (the two test conditions) as well as whether it was a go or SS trial",
+        "publish":"True",
+        "experiment_variables": [{
+                                 "name":"credit_var",
+                                 "type":"credit",
+                                 "datatype": "boolean",
+                                 "description":"True if avg_rt > 200"
+                                  }],
+        "deployment_variables":{"jspsych_init":
+                                        {"fullscreen": true,
+                                        "display_element": "getDisplayElement",
+                                        "on_trial_finish": "addID()"}
+                       			} 
+    
+   }
 ]
+

--- a/cue_control_food/config.json
+++ b/cue_control_food/config.json
@@ -1,55 +1,57 @@
 [
-  {
-    "name": "Cue Control Food",
-    "template": "jspsych",
-    "run": [
-      "static/js/math.min.js",
-      "static/js/jspsych/jspsych.js",
-      "static/js/jspsych/plugins/jspsych-call-function.js",
-      "static/js/jspsych/plugins/jspsych-text.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-text.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-instructions.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-attention-check.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-single-stim.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-categorize.js",
-      "static/js/jspsych/plugins/jspsych-survey-text.js",
-      "static/js/utils/poldrack_utils.js",
-      "static/js/utils/poldrack_fmri_utils.js",
-      "valued_pics.js",
-      "neutral_pics.js",
-      "experiment.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-stop-signal.js",
-      "static/css/jspsych.css",
-      "static/css/default_style.css",
-      "style.css"
-    ],
-    "exp_id": "cue_control_food",
-    "contributors": [
-      "Jamie Li",
-      "Ian Eisenberg",
-      "Patrick Bissett",
-      "Zeynep Enkavi",
-      "Sadiv Parikh",
-      "Russell Poldrack"
-    ],
-    "time": 30,
-    "reference": "http://psycnet.apa.org/journals/xlm/37/2/392/",
-    "notes": "Condition refers to whether the trial is practice or high_freq/low_freq (the two test conditions) as well as whether it was a go or SS trial",
-    "publish": "True",
-    "experiment_variables": [
-      {
-        "name": "credit_var",
-        "type": "credit",
-        "datatype": "boolean",
-        "description": "True if avg_rt > 200"
-      }
-    ],
-    "deployment_variables": {
-      "jspsych_init": {
-        "fullscreen": true,
-        "display_element": "getDisplayElement",
-        "on_trial_finish": "addID('cue_control_food')"
-      }
-    }
-  }
+    {
+        "name": "Cue Control Food",
+        "template":"jspsych",
+        "run": [
+
+				"static/js/math.min.js",
+                "static/js/jspsych/jspsych.js",
+                "static/js/jspsych/plugins/jspsych-call-function.js",
+                "static/js/jspsych/plugins/jspsych-text.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-text.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-instructions.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-attention-check.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-single-stim.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-categorize.js",
+                "static/js/jspsych/plugins/jspsych-survey-text.js", 
+                "static/js/utils/poldrack_utils.js",
+                "static/js/utils/poldrack_fmri_utils.js",
+                "valued_pics.js",
+                "neutral_pics.js",
+                "experiment.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-stop-signal.js",
+                "static/css/jspsych.css",
+                "static/css/default_style.css",
+                "style.css"
+                
+                
+               ],
+        "exp_id": "cue_control_food",
+        "cognitive_atlas_task_id": "tsk_4a57abb949e1a",
+        "contributors": [
+                         "Jamie Li",
+                         "Ian Eisenberg",
+                         "Patrick Bissett",
+                         "Zeynep Enkavi",
+                         "Sadiv Parikh",
+                         "Russell Poldrack"
+                        ], 
+        "time":30,
+        "reference": "http://psycnet.apa.org/journals/xlm/37/2/392/",
+        "notes": "Condition refers to whether the trial is practice or high_freq/low_freq (the two test conditions) as well as whether it was a go or SS trial",
+        "publish":"True",
+        "experiment_variables": [{
+                                 "name":"credit_var",
+                                 "type":"credit",
+                                 "datatype": "boolean",
+                                 "description":"True if avg_rt > 200"
+                                  }],
+        "deployment_variables":{"jspsych_init":
+                                        {"fullscreen": true,
+                                        "display_element": "getDisplayElement",
+                                        "on_trial_finish": "addID('cue_control_food')"}
+                       			} 
+    
+   }
 ]
+

--- a/cue_control_food__fmri/config.json
+++ b/cue_control_food__fmri/config.json
@@ -1,55 +1,57 @@
 [
-  {
-    "name": "Cue-Control-Food-fmri",
-    "template": "jspsych",
-    "run": [
-      "static/js/math.min.js",
-      "static/js/jspsych/jspsych.js",
-      "static/js/jspsych/plugins/jspsych-call-function.js",
-      "static/js/jspsych/plugins/jspsych-text.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-text.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-instructions.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-attention-check.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-single-stim.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-categorize.js",
-      "static/js/jspsych/plugins/jspsych-survey-text.js",
-      "static/js/utils/poldrack_utils.js",
-      "static/js/utils/poldrack_fmri_utils.js",
-      "valued_pics.js",
-      "neutral_pics.js",
-      "experiment.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-stop-signal.js",
-      "static/css/jspsych.css",
-      "static/css/default_style.css",
-      "style.css"
-    ],
-    "exp_id": "cue_control_food__fmri",
-    "contributors": [
-      "Jamie Li",
-      "Ian Eisenberg",
-      "Patrick Bissett",
-      "Zeynep Enkavi",
-      "Sadiv Parikh",
-      "Russell Poldrack"
-    ],
-    "time": 30,
-    "reference": "http://psycnet.apa.org/journals/xlm/37/2/392/",
-    "notes": "Condition refers to whether the trial is practice or high_freq/low_freq (the two test conditions) as well as whether it was a go or SS trial",
-    "publish": "True",
-    "experiment_variables": [
-      {
-        "name": "credit_var",
-        "type": "credit",
-        "datatype": "boolean",
-        "description": "True if avg_rt > 200"
-      }
-    ],
-    "deployment_variables": {
-      "jspsych_init": {
-        "fullscreen": true,
-        "display_element": "getDisplayElement",
-        "on_trial_finish": "addID('cue_control_food__fmri')"
-      }
-    }
-  }
+    {
+        "name": "Cue-Control-Food-fmri",
+        "template":"jspsych",
+        "run": [
+
+				"static/js/math.min.js",
+                "static/js/jspsych/jspsych.js",
+                "static/js/jspsych/plugins/jspsych-call-function.js",
+                "static/js/jspsych/plugins/jspsych-text.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-text.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-instructions.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-attention-check.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-single-stim.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-categorize.js",
+                "static/js/jspsych/plugins/jspsych-survey-text.js", 
+                "static/js/utils/poldrack_utils.js",
+                "static/js/utils/poldrack_fmri_utils.js",
+                "valued_pics.js",
+                "neutral_pics.js",
+                "experiment.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-stop-signal.js",
+                "static/css/jspsych.css",
+                "static/css/default_style.css",
+                "style.css"
+                
+                
+               ],
+        "exp_id": "cue_control_food__fmri",
+        "cognitive_atlas_task_id": "tsk_4a57abb949e1a",
+        "contributors": [
+                         "Jamie Li",
+                         "Ian Eisenberg",
+                         "Patrick Bissett",
+                         "Zeynep Enkavi",
+                         "Sadiv Parikh",
+                         "Russell Poldrack"
+                        ], 
+        "time":30,
+        "reference": "http://psycnet.apa.org/journals/xlm/37/2/392/",
+        "notes": "Condition refers to whether the trial is practice or high_freq/low_freq (the two test conditions) as well as whether it was a go or SS trial",
+        "publish":"True",
+        "experiment_variables": [{
+                                 "name":"credit_var",
+                                 "type":"credit",
+                                 "datatype": "boolean",
+                                 "description":"True if avg_rt > 200"
+                                  }],
+        "deployment_variables":{"jspsych_init":
+                                        {"fullscreen": true,
+                                        "display_element": "getDisplayElement",
+                                        "on_trial_finish": "addID('cue_control_food__fmri')"}
+                       			} 
+    
+   }
 ]
+

--- a/cue_control_food_practice/config.json
+++ b/cue_control_food_practice/config.json
@@ -1,55 +1,57 @@
 [
-  {
-    "name": "Cue Control Food Practice",
-    "template": "jspsych",
-    "run": [
-      "static/js/math.min.js",
-      "static/js/jspsych/jspsych.js",
-      "static/js/jspsych/plugins/jspsych-call-function.js",
-      "static/js/jspsych/plugins/jspsych-text.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-text.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-instructions.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-attention-check.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-single-stim.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-categorize.js",
-      "static/js/jspsych/plugins/jspsych-survey-text.js",
-      "static/js/utils/poldrack_utils.js",
-      "static/js/utils/poldrack_fmri_utils.js",
-      "valued_pics.js",
-      "neutral_pics.js",
-      "experiment.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-stop-signal.js",
-      "static/css/jspsych.css",
-      "static/css/default_style.css",
-      "style.css"
-    ],
-    "exp_id": "cue_control_food_practice",
-    "contributors": [
-      "Jamie Li",
-      "Ian Eisenberg",
-      "Patrick Bissett",
-      "Zeynep Enkavi",
-      "Sadiv Parikh",
-      "Russell Poldrack"
-    ],
-    "time": 30,
-    "reference": "http://psycnet.apa.org/journals/xlm/37/2/392/",
-    "notes": "Condition refers to whether the trial is practice or high_freq/low_freq (the two test conditions) as well as whether it was a go or SS trial",
-    "publish": "True",
-    "experiment_variables": [
-      {
-        "name": "credit_var",
-        "type": "credit",
-        "datatype": "boolean",
-        "description": "True if avg_rt > 200"
-      }
-    ],
-    "deployment_variables": {
-      "jspsych_init": {
-        "fullscreen": true,
-        "display_element": "getDisplayElement",
-        "on_trial_finish": "addID('cue_control_food_practice')"
-      }
-    }
-  }
+    {
+        "name": "Cue Control Food Practice",
+        "template":"jspsych",
+        "run": [
+
+				"static/js/math.min.js",
+                "static/js/jspsych/jspsych.js",
+                "static/js/jspsych/plugins/jspsych-call-function.js",
+                "static/js/jspsych/plugins/jspsych-text.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-text.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-instructions.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-attention-check.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-single-stim.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-categorize.js",
+                "static/js/jspsych/plugins/jspsych-survey-text.js", 
+                "static/js/utils/poldrack_utils.js",
+                "static/js/utils/poldrack_fmri_utils.js",
+                "valued_pics.js",
+                "neutral_pics.js",
+                "experiment.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-stop-signal.js",
+                "static/css/jspsych.css",
+                "static/css/default_style.css",
+                "style.css"
+                
+                
+               ],
+        "exp_id": "cue_control_food_practice",
+        "cognitive_atlas_task_id": "tsk_4a57abb949e1a",
+        "contributors": [
+                         "Jamie Li",
+                         "Ian Eisenberg",
+                         "Patrick Bissett",
+                         "Zeynep Enkavi",
+                         "Sadiv Parikh",
+                         "Russell Poldrack"
+                        ], 
+        "time":30,
+        "reference": "http://psycnet.apa.org/journals/xlm/37/2/392/",
+        "notes": "Condition refers to whether the trial is practice or high_freq/low_freq (the two test conditions) as well as whether it was a go or SS trial",
+        "publish":"True",
+        "experiment_variables": [{
+                                 "name":"credit_var",
+                                 "type":"credit",
+                                 "datatype": "boolean",
+                                 "description":"True if avg_rt > 200"
+                                  }],
+        "deployment_variables":{"jspsych_init":
+                                        {"fullscreen": true,
+                                        "display_element": "getDisplayElement",
+                                        "on_trial_finish": "addID('cue_control_food_practice')"}
+                       			} 
+    
+   }
 ]
+

--- a/cue_control_food_pre_rating/config.json
+++ b/cue_control_food_pre_rating/config.json
@@ -1,55 +1,57 @@
 [
-  {
-    "name": "Cue Control Food Pre Rating",
-    "template": "jspsych",
-    "run": [
-      "static/js/math.min.js",
-      "static/js/jspsych/jspsych.js",
-      "static/js/jspsych/plugins/jspsych-call-function.js",
-      "static/js/jspsych/plugins/jspsych-text.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-text.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-instructions.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-attention-check.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-single-stim.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-categorize.js",
-      "static/js/jspsych/plugins/jspsych-survey-text.js",
-      "static/js/utils/poldrack_utils.js",
-      "static/js/utils/poldrack_fmri_utils.js",
-      "valued_pics.js",
-      "neutral_pics.js",
-      "experiment.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-stop-signal.js",
-      "static/css/jspsych.css",
-      "static/css/default_style.css",
-      "style.css"
-    ],
-    "exp_id": "cue_control_food_pre_rating",
-    "contributors": [
-      "Jamie Li",
-      "Ian Eisenberg",
-      "Patrick Bissett",
-      "Zeynep Enkavi",
-      "Sadiv Parikh",
-      "Russell Poldrack"
-    ],
-    "time": 30,
-    "reference": "http://psycnet.apa.org/journals/xlm/37/2/392/",
-    "notes": "Condition refers to whether the trial is practice or high_freq/low_freq (the two test conditions) as well as whether it was a go or SS trial",
-    "publish": "True",
-    "experiment_variables": [
-      {
-        "name": "credit_var",
-        "type": "credit",
-        "datatype": "boolean",
-        "description": "True if avg_rt > 200"
-      }
-    ],
-    "deployment_variables": {
-      "jspsych_init": {
-        "fullscreen": true,
-        "display_element": "getDisplayElement",
-        "on_trial_finish": "addID('cue_control_food_pre_rating')"
-      }
-    }
-  }
+    {
+        "name": "Cue Control Food Pre Rating",
+        "template":"jspsych",
+        "run": [
+
+				"static/js/math.min.js",
+                "static/js/jspsych/jspsych.js",
+                "static/js/jspsych/plugins/jspsych-call-function.js",
+                "static/js/jspsych/plugins/jspsych-text.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-text.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-instructions.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-attention-check.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-single-stim.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-categorize.js",
+                "static/js/jspsych/plugins/jspsych-survey-text.js",
+                "static/js/utils/poldrack_utils.js",
+                "static/js/utils/poldrack_fmri_utils.js", 
+                "valued_pics.js",
+                "neutral_pics.js",
+                "experiment.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-stop-signal.js",
+                "static/css/jspsych.css",
+                "static/css/default_style.css",
+                "style.css"
+                
+                
+               ],
+        "exp_id": "cue_control_food_pre_rating",
+        "cognitive_atlas_task_id": "tsk_4a57abb949e1a",
+        "contributors": [
+                         "Jamie Li",
+                         "Ian Eisenberg",
+                         "Patrick Bissett",
+                         "Zeynep Enkavi",
+                         "Sadiv Parikh",
+                         "Russell Poldrack"
+                        ], 
+        "time":30,
+        "reference": "http://psycnet.apa.org/journals/xlm/37/2/392/",
+        "notes": "Condition refers to whether the trial is practice or high_freq/low_freq (the two test conditions) as well as whether it was a go or SS trial",
+        "publish":"True",
+        "experiment_variables": [{
+                                 "name":"credit_var",
+                                 "type":"credit",
+                                 "datatype": "boolean",
+                                 "description":"True if avg_rt > 200"
+                                  }],
+        "deployment_variables":{"jspsych_init":
+                                        {"fullscreen": true,
+                                        "display_element": "getDisplayElement",
+                                        "on_trial_finish": "addID('cue_control_food_pre_rating')"}
+                       			} 
+    
+   }
 ]
+

--- a/cue_control_smoking/config.json
+++ b/cue_control_smoking/config.json
@@ -1,55 +1,57 @@
 [
-  {
-    "name": "Cue Control Smoking",
-    "template": "jspsych",
-    "run": [
-      "static/js/math.min.js",
-      "static/js/jspsych/jspsych.js",
-      "static/js/jspsych/plugins/jspsych-call-function.js",
-      "static/js/jspsych/plugins/jspsych-text.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-text.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-instructions.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-attention-check.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-single-stim.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-categorize.js",
-      "static/js/jspsych/plugins/jspsych-survey-text.js",
-      "static/js/utils/poldrack_utils.js",
-      "static/js/utils/poldrack_fmri_utils.js",
-      "valued_pics.js",
-      "neutral_pics.js",
-      "experiment.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-stop-signal.js",
-      "static/css/jspsych.css",
-      "static/css/default_style.css",
-      "style.css"
-    ],
-    "exp_id": "cue_control_smoking",
-    "contributors": [
-      "Jamie Li",
-      "Ian Eisenberg",
-      "Patrick Bissett",
-      "Zeynep Enkavi",
-      "Sadiv Parikh",
-      "Russell Poldrack"
-    ],
-    "time": 30,
-    "reference": "http://psycnet.apa.org/journals/xlm/37/2/392/",
-    "notes": "Condition refers to whether the trial is practice or high_freq/low_freq (the two test conditions) as well as whether it was a go or SS trial",
-    "publish": "True",
-    "experiment_variables": [
-      {
-        "name": "credit_var",
-        "type": "credit",
-        "datatype": "boolean",
-        "description": "True if avg_rt > 200"
-      }
-    ],
-    "deployment_variables": {
-      "jspsych_init": {
-        "fullscreen": true,
-        "display_element": "getDisplayElement",
-        "on_trial_finish": "addID('cue_control_smoking')"
-      }
-    }
-  }
+    {
+        "name": "Cue Control Smoking",
+        "template":"jspsych",
+        "run": [
+
+				"static/js/math.min.js",
+                "static/js/jspsych/jspsych.js",
+                "static/js/jspsych/plugins/jspsych-call-function.js",
+                "static/js/jspsych/plugins/jspsych-text.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-text.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-instructions.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-attention-check.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-single-stim.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-categorize.js",
+                "static/js/jspsych/plugins/jspsych-survey-text.js", 
+                "static/js/utils/poldrack_utils.js",
+                "static/js/utils/poldrack_fmri_utils.js",
+                "valued_pics.js",
+                "neutral_pics.js",
+                "experiment.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-stop-signal.js",
+                "static/css/jspsych.css",
+                "static/css/default_style.css",
+                "style.css"
+                
+                
+               ],
+        "exp_id": "cue_control_smoking",
+        "cognitive_atlas_task_id": "tsk_4a57abb949e1a",
+        "contributors": [
+                         "Jamie Li",
+                         "Ian Eisenberg",
+                         "Patrick Bissett",
+                         "Zeynep Enkavi",
+                         "Sadiv Parikh",
+                         "Russell Poldrack"
+                        ], 
+        "time":30,
+        "reference": "http://psycnet.apa.org/journals/xlm/37/2/392/",
+        "notes": "Condition refers to whether the trial is practice or high_freq/low_freq (the two test conditions) as well as whether it was a go or SS trial",
+        "publish":"True",
+        "experiment_variables": [{
+                                 "name":"credit_var",
+                                 "type":"credit",
+                                 "datatype": "boolean",
+                                 "description":"True if avg_rt > 200"
+                                  }],
+        "deployment_variables":{"jspsych_init":
+                                        {"fullscreen": true,
+                                        "display_element": "getDisplayElement",
+                                        "on_trial_finish": "addID('cue_control_smoking')"}
+                       			} 
+    
+   }
 ]
+

--- a/cue_control_smoking__fmri/config.json
+++ b/cue_control_smoking__fmri/config.json
@@ -1,55 +1,57 @@
 [
-  {
-    "name": "Cue-Control-Smoking-fmri",
-    "template": "jspsych",
-    "run": [
-      "static/js/math.min.js",
-      "static/js/jspsych/jspsych.js",
-      "static/js/jspsych/plugins/jspsych-call-function.js",
-      "static/js/jspsych/plugins/jspsych-text.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-text.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-instructions.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-attention-check.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-single-stim.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-categorize.js",
-      "static/js/jspsych/plugins/jspsych-survey-text.js",
-      "static/js/utils/poldrack_utils.js",
-      "static/js/utils/poldrack_fmri_utils.js",
-      "valued_pics.js",
-      "neutral_pics.js",
-      "experiment.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-stop-signal.js",
-      "static/css/jspsych.css",
-      "static/css/default_style.css",
-      "style.css"
-    ],
-    "exp_id": "cue_control_smoking__fmri",
-    "contributors": [
-      "Jamie Li",
-      "Ian Eisenberg",
-      "Patrick Bissett",
-      "Zeynep Enkavi",
-      "Sadiv Parikh",
-      "Russell Poldrack"
-    ],
-    "time": 30,
-    "reference": "http://psycnet.apa.org/journals/xlm/37/2/392/",
-    "notes": "Condition refers to whether the trial is practice or high_freq/low_freq (the two test conditions) as well as whether it was a go or SS trial",
-    "publish": "True",
-    "experiment_variables": [
-      {
-        "name": "credit_var",
-        "type": "credit",
-        "datatype": "boolean",
-        "description": "True if avg_rt > 200"
-      }
-    ],
-    "deployment_variables": {
-      "jspsych_init": {
-        "fullscreen": true,
-        "display_element": "getDisplayElement",
-        "on_trial_finish": "addID('cue_control_smoking__fmri')"
-      }
-    }
-  }
+    {
+        "name": "Cue-Control-Smoking-fmri",
+        "template":"jspsych",
+        "run": [
+
+				"static/js/math.min.js",
+                "static/js/jspsych/jspsych.js",
+                "static/js/jspsych/plugins/jspsych-call-function.js",
+                "static/js/jspsych/plugins/jspsych-text.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-text.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-instructions.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-attention-check.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-single-stim.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-categorize.js",
+                "static/js/jspsych/plugins/jspsych-survey-text.js", 
+                "static/js/utils/poldrack_utils.js",
+                "static/js/utils/poldrack_fmri_utils.js",
+                "valued_pics.js",
+                "neutral_pics.js",
+                "experiment.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-stop-signal.js",
+                "static/css/jspsych.css",
+                "static/css/default_style.css",
+                "style.css"
+                
+                
+               ],
+        "exp_id": "cue_control_smoking__fmri",
+        "cognitive_atlas_task_id": "tsk_4a57abb949e1a",
+        "contributors": [
+                         "Jamie Li",
+                         "Ian Eisenberg",
+                         "Patrick Bissett",
+                         "Zeynep Enkavi",
+                         "Sadiv Parikh",
+                         "Russell Poldrack"
+                        ], 
+        "time":30,
+        "reference": "http://psycnet.apa.org/journals/xlm/37/2/392/",
+        "notes": "Condition refers to whether the trial is practice or high_freq/low_freq (the two test conditions) as well as whether it was a go or SS trial",
+        "publish":"True",
+        "experiment_variables": [{
+                                 "name":"credit_var",
+                                 "type":"credit",
+                                 "datatype": "boolean",
+                                 "description":"True if avg_rt > 200"
+                                  }],
+        "deployment_variables":{"jspsych_init":
+                                        {"fullscreen": true,
+                                        "display_element": "getDisplayElement",
+                                        "on_trial_finish": "addID('cue_control_smoking__fmri')"}
+                       			} 
+    
+   }
 ]
+

--- a/cue_control_smoking_practice/config.json
+++ b/cue_control_smoking_practice/config.json
@@ -1,55 +1,57 @@
 [
-  {
-    "name": "Cue Control Smoking Practice",
-    "template": "jspsych",
-    "run": [
-      "static/js/math.min.js",
-      "static/js/jspsych/jspsych.js",
-      "static/js/jspsych/plugins/jspsych-call-function.js",
-      "static/js/jspsych/plugins/jspsych-text.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-text.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-instructions.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-attention-check.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-single-stim.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-categorize.js",
-      "static/js/jspsych/plugins/jspsych-survey-text.js",
-      "static/js/utils/poldrack_utils.js",
-      "static/js/utils/poldrack_fmri_utils.js",
-      "valued_pics.js",
-      "neutral_pics.js",
-      "experiment.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-stop-signal.js",
-      "static/css/jspsych.css",
-      "static/css/default_style.css",
-      "style.css"
-    ],
-    "exp_id": "cue_control_smoking_practice",
-    "contributors": [
-      "Jamie Li",
-      "Ian Eisenberg",
-      "Patrick Bissett",
-      "Zeynep Enkavi",
-      "Sadiv Parikh",
-      "Russell Poldrack"
-    ],
-    "time": 30,
-    "reference": "http://psycnet.apa.org/journals/xlm/37/2/392/",
-    "notes": "Condition refers to whether the trial is practice or high_freq/low_freq (the two test conditions) as well as whether it was a go or SS trial",
-    "publish": "True",
-    "experiment_variables": [
-      {
-        "name": "credit_var",
-        "type": "credit",
-        "datatype": "boolean",
-        "description": "True if avg_rt > 200"
-      }
-    ],
-    "deployment_variables": {
-      "jspsych_init": {
-        "fullscreen": true,
-        "display_element": "getDisplayElement",
-        "on_trial_finish": "addID('cue_control_smoking_practice')"
-      }
-    }
-  }
+    {
+        "name": "Cue Control Smoking Practice",
+        "template":"jspsych",
+        "run": [
+
+				"static/js/math.min.js",
+                "static/js/jspsych/jspsych.js",
+                "static/js/jspsych/plugins/jspsych-call-function.js",
+                "static/js/jspsych/plugins/jspsych-text.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-text.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-instructions.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-attention-check.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-single-stim.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-categorize.js",
+                "static/js/jspsych/plugins/jspsych-survey-text.js", 
+                "static/js/utils/poldrack_utils.js",
+                "static/js/utils/poldrack_fmri_utils.js",
+                "valued_pics.js",
+                "neutral_pics.js",
+                "experiment.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-stop-signal.js",
+                "static/css/jspsych.css",
+                "static/css/default_style.css",
+                "style.css"
+                
+                
+               ],
+        "exp_id": "cue_control_smoking_practice",
+        "cognitive_atlas_task_id": "tsk_4a57abb949e1a",
+        "contributors": [
+                         "Jamie Li",
+                         "Ian Eisenberg",
+                         "Patrick Bissett",
+                         "Zeynep Enkavi",
+                         "Sadiv Parikh",
+                         "Russell Poldrack"
+                        ], 
+        "time":30,
+        "reference": "http://psycnet.apa.org/journals/xlm/37/2/392/",
+        "notes": "Condition refers to whether the trial is practice or high_freq/low_freq (the two test conditions) as well as whether it was a go or SS trial",
+        "publish":"True",
+        "experiment_variables": [{
+                                 "name":"credit_var",
+                                 "type":"credit",
+                                 "datatype": "boolean",
+                                 "description":"True if avg_rt > 200"
+                                  }],
+        "deployment_variables":{"jspsych_init":
+                                        {"fullscreen": true,
+                                        "display_element": "getDisplayElement",
+                                        "on_trial_finish": "addID('cue_control_smoking_practice')"}
+                       			} 
+    
+   }
 ]
+

--- a/cue_control_smoking_pre_rating/config.json
+++ b/cue_control_smoking_pre_rating/config.json
@@ -1,55 +1,57 @@
 [
-  {
-    "name": "Cue Control Smoking Pre Rating",
-    "template": "jspsych",
-    "run": [
-      "static/js/math.min.js",
-      "static/js/jspsych/jspsych.js",
-      "static/js/jspsych/plugins/jspsych-call-function.js",
-      "static/js/jspsych/plugins/jspsych-text.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-text.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-instructions.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-attention-check.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-single-stim.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-categorize.js",
-      "static/js/jspsych/plugins/jspsych-survey-text.js",
-      "static/js/utils/poldrack_utils.js",
-      "static/js/utils/poldrack_fmri_utils.js",
-      "valued_pics.js",
-      "neutral_pics.js",
-      "experiment.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-stop-signal.js",
-      "static/css/jspsych.css",
-      "static/css/default_style.css",
-      "style.css"
-    ],
-    "exp_id": "cue_control_smoking_pre_rating",
-    "contributors": [
-      "Jamie Li",
-      "Ian Eisenberg",
-      "Patrick Bissett",
-      "Zeynep Enkavi",
-      "Sadiv Parikh",
-      "Russell Poldrack"
-    ],
-    "time": 30,
-    "reference": "http://psycnet.apa.org/journals/xlm/37/2/392/",
-    "notes": "Condition refers to whether the trial is practice or high_freq/low_freq (the two test conditions) as well as whether it was a go or SS trial",
-    "publish": "True",
-    "experiment_variables": [
-      {
-        "name": "credit_var",
-        "type": "credit",
-        "datatype": "boolean",
-        "description": "True if avg_rt > 200"
-      }
-    ],
-    "deployment_variables": {
-      "jspsych_init": {
-        "fullscreen": true,
-        "display_element": "getDisplayElement",
-        "on_trial_finish": "addID('cue_control_smoking_pre_rating')"
-      }
-    }
-  }
+    {
+        "name": "Cue Control Smoking Pre Rating",
+        "template":"jspsych",
+        "run": [
+
+				"static/js/math.min.js",
+                "static/js/jspsych/jspsych.js",
+                "static/js/jspsych/plugins/jspsych-call-function.js",
+                "static/js/jspsych/plugins/jspsych-text.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-text.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-instructions.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-attention-check.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-single-stim.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-categorize.js",
+                "static/js/jspsych/plugins/jspsych-survey-text.js", 
+                "static/js/utils/poldrack_utils.js",
+                "static/js/utils/poldrack_fmri_utils.js",
+                "valued_pics.js",
+                "neutral_pics.js",
+                "experiment.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-stop-signal.js",
+                "static/css/jspsych.css",
+                "static/css/default_style.css",
+                "style.css"
+                
+                
+               ],
+        "exp_id": "cue_control_smoking_pre_rating",
+        "cognitive_atlas_task_id": "tsk_4a57abb949e1a",
+        "contributors": [
+                         "Jamie Li",
+                         "Ian Eisenberg",
+                         "Patrick Bissett",
+                         "Zeynep Enkavi",
+                         "Sadiv Parikh",
+                         "Russell Poldrack"
+                        ], 
+        "time":30,
+        "reference": "http://psycnet.apa.org/journals/xlm/37/2/392/",
+        "notes": "Condition refers to whether the trial is practice or high_freq/low_freq (the two test conditions) as well as whether it was a go or SS trial",
+        "publish":"True",
+        "experiment_variables": [{
+                                 "name":"credit_var",
+                                 "type":"credit",
+                                 "datatype": "boolean",
+                                 "description":"True if avg_rt > 200"
+                                  }],
+        "deployment_variables":{"jspsych_init":
+                                        {"fullscreen": true,
+                                        "display_element": "getDisplayElement",
+                                        "on_trial_finish": "addID('cue_control_smoking_pre_rating')"}
+                       			} 
+    
+   }
 ]
+

--- a/directed_forgetting_with_shape_matching/config.json
+++ b/directed_forgetting_with_shape_matching/config.json
@@ -1,48 +1,46 @@
 [
-  {
-    "name": "Directed Forgetting with Shape Matching Experiment",
-    "template": "jspsych",
-    "run": [
-      "static/js/math.min.js",
-      "static/js/jspsych/jspsych.js",
-      "static/js/jspsych/plugins/jspsych-text.js",
-      "static/js/jspsych/plugins/jspsych-call-function.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-text.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-categorize.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-instructions.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-attention-check.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-single-stim.js",
-      "static/js/jspsych/plugins/jspsych-survey-text.js",
-      "static/js/utils/poldrack_utils.js",
-      "experiment.js",
-      "static/css/jspsych.css",
-      "static/css/default_style.css",
-      "style.css"
-    ],
-    "exp_id": "directed_forgetting_with_shape_matching",
-    "contributors": [
-      "Patrick Bissett",
-      "Jamie Li",
-      "McKenzie Hagen",
-      "Russell Poldrack"
-    ],
-    "time": 22,
-    "reference": "http://www.ncbi.nlm.nih.gov/pmc/articles/PMC2206737/",
-    "publish": "True",
-    "experiment_variables": [
-      {
-        "name": "credit_var",
-        "type": "credit",
-        "datatype": "boolean",
-        "description": "True if avg_rt > 200"
-      }
-    ],
-    "deployment_variables": {
-      "jspsych_init": {
-        "fullscreen": true,
-        "display_element": "getDisplayElement",
-        "on_trial_finish": "addID('directed_forgetting_with_shape_matching')"
-      }
-    }
-  }
+    {
+        "name": "Directed Forgetting with Shape Matching Experiment",
+        "template":"jspsych",
+        "run": [
+                 "static/js/math.min.js",
+                 "static/js/jspsych/jspsych.js",
+                 "static/js/jspsych/plugins/jspsych-text.js",
+                 "static/js/jspsych/plugins/jspsych-call-function.js",
+                 "static/js/jspsych/poldrack_plugins/jspsych-poldrack-text.js",
+                 "static/js/jspsych/poldrack_plugins/jspsych-poldrack-categorize.js",
+                 "static/js/jspsych/poldrack_plugins/jspsych-poldrack-instructions.js",
+                 "static/js/jspsych/poldrack_plugins/jspsych-attention-check.js",
+                 "static/js/jspsych/poldrack_plugins/jspsych-poldrack-single-stim.js",
+                 "static/js/jspsych/plugins/jspsych-survey-text.js",
+                 "static/js/utils/poldrack_utils.js",
+                 "experiment.js",
+                 "static/css/jspsych.css",
+                 "static/css/default_style.css",
+                 "style.css"
+               ],
+        "exp_id": "directed_forgetting_with_shape_matching",
+        "cognitive_atlas_task_id": "trm_56674c7c2fa4f",
+        "contributors": [
+                         "Patrick Bissett",
+                         "Jamie Li",
+                         "McKenzie Hagen",
+                         "Russell Poldrack"
+                        ], 
+        "time":22,
+        "reference": "http://www.ncbi.nlm.nih.gov/pmc/articles/PMC2206737/",
+        "publish":"True",
+        "experiment_variables": [{
+                                 "name":"credit_var",
+                                 "type":"credit",
+                                 "datatype": "boolean",
+                                 "description":"True if avg_rt > 200"
+                                  }],
+        "deployment_variables":{"jspsych_init":
+                                        {"fullscreen": true,
+                                        "display_element": "getDisplayElement",
+                                        "on_trial_finish": "addID('directed_forgetting_with_shape_matching')"}
+                       }
+    
+   }
 ]

--- a/eating_followup_survey__dartmouth/config.json
+++ b/eating_followup_survey__dartmouth/config.json
@@ -1,49 +1,51 @@
 [
-  {
-    "name": "Eating Follow-up Survey (Dartmouth)",
-    "template": "jspsych",
-    "run": [
-      "static/js/jspsych/jspsych.js",
-      "static/js/jspsych/plugins/jspsych-call-function.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-text.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-instructions.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-attention-check.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-single-stim.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-categorize.js",
-      "static/js/jspsych/plugins/jspsych-survey-text.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-stop-signal.js",
-      "static/css/jspsych.css",
-      "static/css/default_style.css",
-      "style.css",
-      "experiment.js"
-    ],
-    "exp_id": "eating_followup_survey__dartmouth",
-    "contributors": [
-      "Jamie Li",
-      "Ian Eisenberg",
-      "Patrick Bissett",
-      "Zeynep Enkavi",
-      "Sadiv Parikh",
-      "Russell Poldrack"
-    ],
-    "time": 30,
-    "reference": "http://psycnet.apa.org/journals/xlm/37/2/392/",
-    "notes": "Condition refers to whether the trial is practice or high_freq/low_freq (the two test conditions) as well as whether it was a go or SS trial",
-    "publish": "True",
-    "experiment_variables": [
-      {
-        "name": "credit_var",
-        "type": "credit",
-        "datatype": "boolean",
-        "description": "True if avg_rt > 200"
-      }
-    ],
-    "deployment_variables": {
-      "jspsych_init": {
-        "fullscreen": true,
-        "display_element": "getDisplayElement",
-        "on_trial_finish": "addID()"
-      }
-    }
-  }
+    {
+        "name": "Eating Follow-up Survey (Dartmouth)",
+        "template":"jspsych",
+        "run": [
+
+                "static/js/jspsych/jspsych.js",
+                "static/js/jspsych/plugins/jspsych-call-function.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-text.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-instructions.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-attention-check.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-single-stim.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-categorize.js",
+                "static/js/jspsych/plugins/jspsych-survey-text.js", 
+                "static/js/jspsych/poldrack_plugins/jspsych-stop-signal.js",
+                "static/css/jspsych.css",
+                "static/css/default_style.css",
+                "style.css",
+                "experiment.js"
+                
+                
+               ],
+        "exp_id": "eating_followup_survey__dartmouth",
+        "cognitive_atlas_task_id": "tsk_4a57abb949e1a",
+        "contributors": [
+                         "Jamie Li",
+                         "Ian Eisenberg",
+                         "Patrick Bissett",
+                         "Zeynep Enkavi",
+                         "Sadiv Parikh",
+                         "Russell Poldrack"
+                        ], 
+        "time":30,
+        "reference": "http://psycnet.apa.org/journals/xlm/37/2/392/",
+        "notes": "Condition refers to whether the trial is practice or high_freq/low_freq (the two test conditions) as well as whether it was a go or SS trial",
+        "publish":"True",
+        "experiment_variables": [{
+                                 "name":"credit_var",
+                                 "type":"credit",
+                                 "datatype": "boolean",
+                                 "description":"True if avg_rt > 200"
+                                  }],
+        "deployment_variables":{"jspsych_init":
+                                        {"fullscreen": true,
+                                        "display_element": "getDisplayElement",
+                                        "on_trial_finish": "addID()"}
+                       			} 
+    
+   }
 ]
+

--- a/eating_followup_survey__stanford/config.json
+++ b/eating_followup_survey__stanford/config.json
@@ -1,49 +1,51 @@
 [
-  {
-    "name": "Eating Follow-up Survey (Stanford)",
-    "template": "jspsych",
-    "run": [
-      "static/js/jspsych/jspsych.js",
-      "static/js/jspsych/plugins/jspsych-call-function.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-text.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-instructions.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-attention-check.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-single-stim.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-categorize.js",
-      "static/js/jspsych/plugins/jspsych-survey-text.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-stop-signal.js",
-      "static/css/jspsych.css",
-      "static/css/default_style.css",
-      "style.css",
-      "experiment.js"
-    ],
-    "exp_id": "eating_followup_survey__stanford",
-    "contributors": [
-      "Jamie Li",
-      "Ian Eisenberg",
-      "Patrick Bissett",
-      "Zeynep Enkavi",
-      "Sadiv Parikh",
-      "Russell Poldrack"
-    ],
-    "time": 30,
-    "reference": "http://psycnet.apa.org/journals/xlm/37/2/392/",
-    "notes": "Condition refers to whether the trial is practice or high_freq/low_freq (the two test conditions) as well as whether it was a go or SS trial",
-    "publish": "True",
-    "experiment_variables": [
-      {
-        "name": "credit_var",
-        "type": "credit",
-        "datatype": "boolean",
-        "description": "True if avg_rt > 200"
-      }
-    ],
-    "deployment_variables": {
-      "jspsych_init": {
-        "fullscreen": true,
-        "display_element": "getDisplayElement",
-        "on_trial_finish": "addID()"
-      }
-    }
-  }
+    {
+        "name": "Eating Follow-up Survey (Stanford)",
+        "template":"jspsych",
+        "run": [
+
+                "static/js/jspsych/jspsych.js",
+                "static/js/jspsych/plugins/jspsych-call-function.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-text.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-instructions.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-attention-check.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-single-stim.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-categorize.js",
+                "static/js/jspsych/plugins/jspsych-survey-text.js", 
+                "static/js/jspsych/poldrack_plugins/jspsych-stop-signal.js",
+                "static/css/jspsych.css",
+                "static/css/default_style.css",
+                "style.css",
+                "experiment.js"
+                
+                
+               ],
+        "exp_id": "eating_followup_survey__stanford",
+        "cognitive_atlas_task_id": "tsk_4a57abb949e1a",
+        "contributors": [
+                         "Jamie Li",
+                         "Ian Eisenberg",
+                         "Patrick Bissett",
+                         "Zeynep Enkavi",
+                         "Sadiv Parikh",
+                         "Russell Poldrack"
+                        ], 
+        "time":30,
+        "reference": "http://psycnet.apa.org/journals/xlm/37/2/392/",
+        "notes": "Condition refers to whether the trial is practice or high_freq/low_freq (the two test conditions) as well as whether it was a go or SS trial",
+        "publish":"True",
+        "experiment_variables": [{
+                                 "name":"credit_var",
+                                 "type":"credit",
+                                 "datatype": "boolean",
+                                 "description":"True if avg_rt > 200"
+                                  }],
+        "deployment_variables":{"jspsych_init":
+                                        {"fullscreen": true,
+                                        "display_element": "getDisplayElement",
+                                        "on_trial_finish": "addID()"}
+                       			} 
+    
+   }
 ]
+

--- a/emotion_regulation/config.json
+++ b/emotion_regulation/config.json
@@ -1,39 +1,38 @@
 [
-  {
-    "name": "Emotion Regulation Task",
-    "template": "jspsych",
-    "run": [
-      "static/js/jspsych/jspsych.js",
-      "static/js/jspsych/plugins/jspsych-text.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-text.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-instructions.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-attention-check.js",
-      "static/js/jspsych/plugins/jspsych-call-function.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-single-stim.js",
-      "static/js/jspsych/plugins/jspsych-survey-text.js",
-      "static/js/utils/poldrack_utils.js",
-      "experiment.js",
-      "static/css/jspsych.css",
-      "static/css/default_style.css",
-      "style.css"
-    ],
-    "exp_id": "emotion_regulation",
-    "contributors": [
-      "Ian Eisenberg",
-      "Zeynep Enkavi",
-      "Patrick Bissett",
-      "Vanessa Sochat",
-      "Russell Poldrack"
-    ],
-    "time": 10,
-    "reference": "http://pss.sagepub.com/content/early/2011/09/28/0956797611418350.abstract",
-    "publish": "True",
-    "deployment_variables": {
-      "jspsych_init": {
-        "fullscreen": true,
-        "display_element": "getDisplayElement",
-        "on_trial_finish": "addID('emotion_regulation')"
-      }
-    }
-  }
+    {
+        "name": "Emotion Regulation Task",
+        "template":"jspsych",
+        "run": [
+                "static/js/jspsych/jspsych.js",
+                "static/js/jspsych/plugins/jspsych-text.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-text.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-instructions.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-attention-check.js",
+                "static/js/jspsych/plugins/jspsych-call-function.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-single-stim.js",
+                "static/js/jspsych/plugins/jspsych-survey-text.js",
+                "static/js/utils/poldrack_utils.js",
+                "experiment.js",
+                "static/css/jspsych.css",
+                "static/css/default_style.css",
+                "style.css"
+               ],
+        "exp_id": "emotion_regulation",
+        "cognitive_atlas_task_id": "trm_4da890594742a",
+        "contributors": [
+                         "Ian Eisenberg",
+                         "Zeynep Enkavi",
+                         "Patrick Bissett",
+                         "Vanessa Sochat",
+                         "Russell Poldrack"
+                        ], 
+        "time": 10,
+        "reference": "http://pss.sagepub.com/content/early/2011/09/28/0956797611418350.abstract",
+        "publish":"True",
+        "deployment_variables":{"jspsych_init":
+                                        {"fullscreen": true,
+                                        "display_element": "getDisplayElement",
+                                        "on_trial_finish": "addID('emotion_regulation')"}
+                       }
+   }
 ]

--- a/flanker_with_predictable_task_switching/config.json
+++ b/flanker_with_predictable_task_switching/config.json
@@ -1,48 +1,47 @@
 [
-  {
-    "name": "Flanker with Predictable Task Switching",
-    "template": "jspsych",
-    "run": [
-      "static/js/math.min.js",
-      "static/js/jspsych/jspsych.js",
-      "static/js/jspsych/plugins/jspsych-text.js",
-      "static/js/jspsych/plugins/jspsych-call-function.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-text.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-instructions.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-single-stim.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-categorize.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-attention-check.js",
-      "static/js/jspsych/plugins/jspsych-survey-text.js",
-      "static/js/utils/poldrack_utils.js",
-      "experiment.js",
-      "static/css/jspsych.css",
-      "static/css/default_style.css",
-      "style.css"
-    ],
-    "exp_id": "flanker_with_predictable_task_switching",
-    "contributors": [
-      "Patrick Bissett",
-      "Jamie Li",
-      "McKenzie Hagen",
-      "Russell Poldrack"
-    ],
-    "time": 20,
-    "reference": "http://psycnet.apa.org/psycarticles/2013-29647-001",
-    "publish": "True",
-    "experiment_variables": [
-      {
-        "name": "credit_var",
-        "type": "credit",
-        "datatype": "boolean",
-        "description": "True if avg_rt > 200"
-      }
-    ],
-    "deployment_variables": {
-      "jspsych_init": {
-        "fullscreen": true,
-        "display_element": "getDisplayElement",
-        "on_trial_finish": "addID('flanker_with_predictable_task_switching')"
-      }
-    }
-  }
+    {
+        "name": "Flanker with Predictable Task Switching",
+        "template":"jspsych",
+        "run": [
+                "static/js/math.min.js",
+                "static/js/jspsych/jspsych.js",
+                "static/js/jspsych/plugins/jspsych-text.js",
+                "static/js/jspsych/plugins/jspsych-call-function.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-text.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-instructions.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-single-stim.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-categorize.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-attention-check.js",
+                "static/js/jspsych/plugins/jspsych-survey-text.js",
+                "static/js/utils/poldrack_utils.js",
+                "experiment.js",
+                "static/css/jspsych.css",
+                "static/css/default_style.css",
+                "style.css"
+               ],
+        "exp_id": "flanker_with_predictable_task_switching",
+        "cognitive_atlas_task_id": "trm_4f241ee9c4e37",
+        "contributors": [
+                         "Patrick Bissett",
+                         "Jamie Li",
+                         "McKenzie Hagen",
+                         "Russell Poldrack"
+                        ], 
+        "time":20,
+        "reference": "http://psycnet.apa.org/psycarticles/2013-29647-001",
+        "publish":"True",
+        "experiment_variables": [{
+                                 "name":"credit_var",
+                                 "type":"credit",
+                                 "datatype": "boolean",
+                                 "description":"True if avg_rt > 200"
+                                  }],
+        "deployment_variables":{"jspsych_init":
+                                        {"fullscreen": true,
+                                        "display_element": "getDisplayElement",
+                                        "on_trial_finish": "addID('flanker_with_predictable_task_switching')"}
+                       }
+    
+   }
 ]
+

--- a/flanker_with_shape_matching/config.json
+++ b/flanker_with_shape_matching/config.json
@@ -1,48 +1,47 @@
 [
-  {
-    "name": "Flanker with Shape Matching",
-    "template": "jspsych",
-    "run": [
-      "static/js/math.min.js",
-      "static/js/jspsych/jspsych.js",
-      "static/js/jspsych/plugins/jspsych-text.js",
-      "static/js/jspsych/plugins/jspsych-call-function.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-text.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-instructions.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-single-stim.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-categorize.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-attention-check.js",
-      "static/js/jspsych/plugins/jspsych-survey-text.js",
-      "static/js/utils/poldrack_utils.js",
-      "experiment.js",
-      "static/css/jspsych.css",
-      "static/css/default_style.css",
-      "style.css"
-    ],
-    "exp_id": "flanker_with_shape_matching",
-    "contributors": [
-      "Patrick Bissett",
-      "Jamie Li",
-      "McKenzie Hagen",
-      "Russell Poldrack"
-    ],
-    "time": 20,
-    "reference": "http://psycnet.apa.org/psycarticles/2013-29647-001",
-    "publish": "True",
-    "experiment_variables": [
-      {
-        "name": "credit_var",
-        "type": "credit",
-        "datatype": "boolean",
-        "description": "True if avg_rt > 200"
-      }
-    ],
-    "deployment_variables": {
-      "jspsych_init": {
-        "fullscreen": true,
-        "display_element": "getDisplayElement",
-        "on_trial_finish": "addID('flanker_with_shape_matching')"
-      }
-    }
-  }
+    {
+        "name": "Flanker with Shape Matching",
+        "template":"jspsych",
+        "run": [
+                "static/js/math.min.js",
+                "static/js/jspsych/jspsych.js",
+                "static/js/jspsych/plugins/jspsych-text.js",
+                "static/js/jspsych/plugins/jspsych-call-function.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-text.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-instructions.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-single-stim.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-categorize.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-attention-check.js",
+                "static/js/jspsych/plugins/jspsych-survey-text.js",
+                "static/js/utils/poldrack_utils.js",
+                "experiment.js",
+                "static/css/jspsych.css",
+                "static/css/default_style.css",
+                "style.css"
+               ],
+        "exp_id": "flanker_with_shape_matching",
+        "cognitive_atlas_task_id": "trm_4f241ee9c4e37",
+        "contributors": [
+                         "Patrick Bissett",
+                         "Jamie Li",
+                         "McKenzie Hagen",
+                         "Russell Poldrack"
+                        ], 
+        "time":20,
+        "reference": "http://psycnet.apa.org/psycarticles/2013-29647-001",
+        "publish":"True",
+        "experiment_variables": [{
+                                 "name":"credit_var",
+                                 "type":"credit",
+                                 "datatype": "boolean",
+                                 "description":"True if avg_rt > 200"
+                                  }],
+        "deployment_variables":{"jspsych_init":
+                                        {"fullscreen": true,
+                                        "display_element": "getDisplayElement",
+                                        "on_trial_finish": "addID('flanker_with_shape_matching')"}
+                       }
+    
+   }
 ]
+

--- a/go_nogo_with_flanker/config.json
+++ b/go_nogo_with_flanker/config.json
@@ -1,48 +1,47 @@
 [
-  {
-    "name": "Go No-Go with Flanker",
-    "template": "jspsych",
-    "run": [
-      "static/js/math.min.js",
-      "static/js/jspsych/jspsych.js",
-      "static/js/jspsych/plugins/jspsych-text.js",
-      "static/js/jspsych/plugins/jspsych-call-function.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-text.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-instructions.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-single-stim.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-categorize.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-attention-check.js",
-      "static/js/jspsych/plugins/jspsych-survey-text.js",
-      "static/js/utils/poldrack_utils.js",
-      "experiment.js",
-      "static/css/jspsych.css",
-      "static/css/default_style.css",
-      "style.css"
-    ],
-    "exp_id": "go_nogo_with_flanker",
-    "contributors": [
-      "Patrick Bissett",
-      "Jamie Li",
-      "McKenzie Hagen",
-      "Russell Poldrack"
-    ],
-    "time": 20,
-    "reference": "http://psycnet.apa.org/psycarticles/2013-29647-001",
-    "publish": "True",
-    "experiment_variables": [
-      {
-        "name": "credit_var",
-        "type": "credit",
-        "datatype": "boolean",
-        "description": "True if avg_rt > 200"
-      }
-    ],
-    "deployment_variables": {
-      "jspsych_init": {
-        "fullscreen": true,
-        "display_element": "getDisplayElement",
-        "on_trial_finish": "addID('go_nogo_with_flanker')"
-      }
-    }
-  }
+    {
+        "name": "Go No-Go with Flanker",
+        "template":"jspsych",
+        "run": [
+                "static/js/math.min.js",
+                "static/js/jspsych/jspsych.js",
+                "static/js/jspsych/plugins/jspsych-text.js",
+                "static/js/jspsych/plugins/jspsych-call-function.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-text.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-instructions.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-single-stim.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-categorize.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-attention-check.js",
+                "static/js/jspsych/plugins/jspsych-survey-text.js",
+                "static/js/utils/poldrack_utils.js",
+                "experiment.js",
+                "static/css/jspsych.css",
+                "static/css/default_style.css",
+                "style.css"
+               ],
+        "exp_id": "go_nogo_with_flanker",
+        "cognitive_atlas_task_id": "trm_4f241ee9c4e37",
+        "contributors": [
+                         "Patrick Bissett",
+                         "Jamie Li",
+                         "McKenzie Hagen",
+                         "Russell Poldrack"
+                        ], 
+        "time":20,
+        "reference": "http://psycnet.apa.org/psycarticles/2013-29647-001",
+        "publish":"True",
+        "experiment_variables": [{
+                                 "name":"credit_var",
+                                 "type":"credit",
+                                 "datatype": "boolean",
+                                 "description":"True if avg_rt > 200"
+                                  }],
+        "deployment_variables":{"jspsych_init":
+                                        {"fullscreen": true,
+                                        "display_element": "getDisplayElement",
+                                        "on_trial_finish": "addID('go_nogo_with_flanker')"}
+                       }
+    
+   }
 ]
+

--- a/go_nogo_with_n_back/config.json
+++ b/go_nogo_with_n_back/config.json
@@ -1,47 +1,48 @@
 [
-  {
-    "name": "Go No-Go with N-Back",
-    "template": "jspsych",
-    "run": [
-      "static/js/math.min.js",
-      "static/js/jspsych/jspsych.js",
-      "static/js/jspsych/plugins/jspsych-call-function.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-text.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-instructions.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-attention-check.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-single-stim.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-categorize.js",
-      "static/js/jspsych/plugins/jspsych-survey-text.js",
-      "experiment.js",
-      "static/css/jspsych.css",
-      "static/css/default_style.css",
-      "style.css",
-      "https://cdnjs.cloudflare.com/ajax/libs/mathjs/3.13.3/math.js"
-    ],
-    "exp_id": "go_nogo_with_n_back",
-    "contributors": [
-      "Jamie Li",
-      "Patrick Bissett",
-      "Russell Poldrack"
-    ],
-    "time": 30,
-    "reference": "http://psycnet.apa.org/journals/xlm/37/2/392/",
-    "notes": "Condition refers to whether the trial is practice or high_freq/low_freq (the two test conditions) as well as whether it was a go or SS trial",
-    "publish": "True",
-    "experiment_variables": [
-      {
-        "name": "credit_var",
-        "type": "credit",
-        "datatype": "boolean",
-        "description": "True if avg_rt > 200"
-      }
-    ],
-    "deployment_variables": {
-      "jspsych_init": {
-        "fullscreen": true,
-        "display_element": "getDisplayElement",
-        "on_trial_finish": "addID('go_nogo_with_n_back')"
-      }
-    }
-  }
+    {
+        "name": "Go No-Go with N-Back",
+        "template":"jspsych",
+        "run": [
+				"static/js/math.min.js",
+                "static/js/jspsych/jspsych.js",
+                "static/js/jspsych/plugins/jspsych-call-function.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-text.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-instructions.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-attention-check.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-single-stim.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-categorize.js",
+                "static/js/jspsych/plugins/jspsych-survey-text.js", 
+                "experiment.js",
+                "static/css/jspsych.css",
+                "static/css/default_style.css",
+                "style.css",
+                "https://cdnjs.cloudflare.com/ajax/libs/mathjs/3.13.3/math.js"
+                
+                
+               ],
+        "exp_id": "go_nogo_with_n_back",
+        "cognitive_atlas_task_id": "tsk_4a57abb949e1a",
+        "contributors": [
+                         "Jamie Li",
+                         "Patrick Bissett",
+                         "Russell Poldrack"
+                        ], 
+        "time":30,
+        "reference": "http://psycnet.apa.org/journals/xlm/37/2/392/",
+        "notes": "Condition refers to whether the trial is practice or high_freq/low_freq (the two test conditions) as well as whether it was a go or SS trial",
+        "publish":"True",
+        "experiment_variables": [{
+                                 "name":"credit_var",
+                                 "type":"credit",
+                                 "datatype": "boolean",
+                                 "description":"True if avg_rt > 200"
+                                  }],
+        "deployment_variables":{"jspsych_init":
+                                        {"fullscreen": true,
+                                        "display_element": "getDisplayElement",
+                                        "on_trial_finish": "addID('go_nogo_with_n_back')"}
+                       			} 
+    
+   }
 ]
+

--- a/go_nogo_with_predictable_task_switching/config.json
+++ b/go_nogo_with_predictable_task_switching/config.json
@@ -1,48 +1,47 @@
 [
-  {
-    "name": "Go No-Go with Predictable Task Switching",
-    "template": "jspsych",
-    "run": [
-      "static/js/math.min.js",
-      "static/js/jspsych/jspsych.js",
-      "static/js/jspsych/plugins/jspsych-text.js",
-      "static/js/jspsych/plugins/jspsych-call-function.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-text.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-instructions.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-single-stim.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-categorize.js",
-      "static/js/jspsych/plugins/jspsych-survey-text.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-attention-check.js",
-      "static/js/utils/poldrack_utils.js",
-      "experiment.js",
-      "static/css/jspsych.css",
-      "static/css/default_style.css",
-      "style.css"
-    ],
-    "exp_id": "go_nogo_with_predictable_task_switching",
-    "contributors": [
-      "Patrick Bissett",
-      "Jamie Li",
-      "McKenzie Hagen",
-      "Russell Poldrack"
-    ],
-    "time": 20,
-    "reference": "http://psycnet.apa.org/psycarticles/2013-29647-001",
-    "publish": "True",
-    "experiment_variables": [
-      {
-        "name": "credit_var",
-        "type": "credit",
-        "datatype": "boolean",
-        "description": "True if avg_rt > 200"
-      }
-    ],
-    "deployment_variables": {
-      "jspsych_init": {
-        "fullscreen": true,
-        "display_element": "getDisplayElement",
-        "on_trial_finish": "addID('go_nogo_with_predictable_task_switching')"
-      }
-    }
-  }
+    {
+        "name": "Go No-Go with Predictable Task Switching",
+        "template":"jspsych",
+        "run": [
+                "static/js/math.min.js",
+                "static/js/jspsych/jspsych.js",
+                "static/js/jspsych/plugins/jspsych-text.js",
+                "static/js/jspsych/plugins/jspsych-call-function.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-text.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-instructions.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-single-stim.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-categorize.js",
+                "static/js/jspsych/plugins/jspsych-survey-text.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-attention-check.js",
+                "static/js/utils/poldrack_utils.js",
+                "experiment.js",
+                "static/css/jspsych.css",
+                "static/css/default_style.css",
+                "style.css"
+               ],
+        "exp_id": "go_nogo_with_predictable_task_switching",
+        "cognitive_atlas_task_id": "trm_4f241ee9c4e37",
+        "contributors": [
+                         "Patrick Bissett",
+                         "Jamie Li",
+                         "McKenzie Hagen",
+                         "Russell Poldrack"
+                        ], 
+        "time":20,
+        "reference": "http://psycnet.apa.org/psycarticles/2013-29647-001",
+        "publish":"True",
+        "experiment_variables": [{
+                                 "name":"credit_var",
+                                 "type":"credit",
+                                 "datatype": "boolean",
+                                 "description":"True if avg_rt > 200"
+                                  }],
+        "deployment_variables":{"jspsych_init":
+                                        {"fullscreen": true,
+                                        "display_element": "getDisplayElement",
+                                        "on_trial_finish": "addID('go_nogo_with_predictable_task_switching')"}
+                       }
+    
+   }
 ]
+

--- a/go_nogo_with_shape_matching/config.json
+++ b/go_nogo_with_shape_matching/config.json
@@ -1,48 +1,47 @@
 [
-  {
-    "name": "Go No-Go with Shape Matching",
-    "template": "jspsych",
-    "run": [
-      "static/js/math.min.js",
-      "static/js/jspsych/jspsych.js",
-      "static/js/jspsych/plugins/jspsych-text.js",
-      "static/js/jspsych/plugins/jspsych-call-function.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-text.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-instructions.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-single-stim.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-categorize.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-attention-check.js",
-      "static/js/jspsych/plugins/jspsych-survey-text.js",
-      "static/js/utils/poldrack_utils.js",
-      "experiment.js",
-      "static/css/jspsych.css",
-      "static/css/default_style.css",
-      "style.css"
-    ],
-    "exp_id": "go_nogo_with_shape_matching",
-    "contributors": [
-      "Jamie Li",
-      "Ian Eisenberg",
-      "Patrick Bissett",
-      "Russell Poldrack"
-    ],
-    "time": 20,
-    "reference": "http://psycnet.apa.org/psycarticles/2013-29647-001",
-    "publish": "True",
-    "experiment_variables": [
-      {
-        "name": "credit_var",
-        "type": "credit",
-        "datatype": "boolean",
-        "description": "True if avg_rt > 200"
-      }
-    ],
-    "deployment_variables": {
-      "jspsych_init": {
-        "fullscreen": true,
-        "display_element": "getDisplayElement",
-        "on_trial_finish": "addID('go_nogo_with_shape_matching')"
-      }
-    }
-  }
+    {
+        "name": "Go No-Go with Shape Matching",
+        "template":"jspsych",
+        "run": [
+                "static/js/math.min.js",
+                "static/js/jspsych/jspsych.js",
+                "static/js/jspsych/plugins/jspsych-text.js",
+                "static/js/jspsych/plugins/jspsych-call-function.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-text.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-instructions.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-single-stim.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-categorize.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-attention-check.js",
+                "static/js/jspsych/plugins/jspsych-survey-text.js",
+                "static/js/utils/poldrack_utils.js",
+                "experiment.js",
+                "static/css/jspsych.css",
+                "static/css/default_style.css",
+                "style.css"
+               ],
+        "exp_id": "go_nogo_with_shape_matching",
+        "cognitive_atlas_task_id": "trm_4f241ee9c4e37",
+        "contributors": [
+                         "Jamie Li",
+                         "Ian Eisenberg",
+                         "Patrick Bissett",
+                         "Russell Poldrack"
+                        ], 
+        "time":20,
+        "reference": "http://psycnet.apa.org/psycarticles/2013-29647-001",
+        "publish":"True",
+        "experiment_variables": [{
+                                 "name":"credit_var",
+                                 "type":"credit",
+                                 "datatype": "boolean",
+                                 "description":"True if avg_rt > 200"
+                                  }],
+        "deployment_variables":{"jspsych_init":
+                                        {"fullscreen": true,
+                                        "display_element": "getDisplayElement",
+                                        "on_trial_finish": "addID('go_nogo_with_shape_matching')"}
+                       }
+    
+   }
 ]
+

--- a/n_back_single_task_network/config.json
+++ b/n_back_single_task_network/config.json
@@ -1,49 +1,50 @@
 [
-  {
-    "name": "N-Back Single Task Network",
-    "template": "jspsych",
-    "run": [
-      "static/js/math.min.js",
-      "static/js/jspsych/jspsych.js",
-      "static/js/jspsych/plugins/jspsych-call-function.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-text.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-instructions.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-attention-check.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-single-stim.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-categorize.js",
-      "static/js/jspsych/plugins/jspsych-survey-text.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-stop-signal.js",
-      "experiment.js",
-      "static/css/jspsych.css",
-      "static/css/default_style.css",
-      "style.css",
-      "https://cdnjs.cloudflare.com/ajax/libs/mathjs/3.13.3/math.js"
-    ],
-    "exp_id": "n_back_single_task_network",
-    "contributors": [
-      "Patrick Bissett",
-      "Jamie Li",
-      "McKenzie Hagen",
-      "Russell Poldrack"
-    ],
-    "time": 30,
-    "reference": "http://psycnet.apa.org/journals/xlm/37/2/392/",
-    "notes": "Condition refers to whether the trial is practice or high_freq/low_freq (the two test conditions) as well as whether it was a go or SS trial",
-    "publish": "True",
-    "experiment_variables": [
-      {
-        "name": "credit_var",
-        "type": "credit",
-        "datatype": "boolean",
-        "description": "True if avg_rt > 200"
-      }
-    ],
-    "deployment_variables": {
-      "jspsych_init": {
-        "fullscreen": true,
-        "display_element": "getDisplayElement",
-        "on_trial_finish": "addID('n_back_single_task_network')"
-      }
-    }
-  }
+    {
+        "name": "N-Back Single Task Network",
+        "template":"jspsych",
+        "run": [
+				"static/js/math.min.js",
+                "static/js/jspsych/jspsych.js",
+                "static/js/jspsych/plugins/jspsych-call-function.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-text.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-instructions.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-attention-check.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-single-stim.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-categorize.js",
+                "static/js/jspsych/plugins/jspsych-survey-text.js", 
+                "static/js/jspsych/poldrack_plugins/jspsych-stop-signal.js",
+                "experiment.js",
+                "static/css/jspsych.css",
+                "static/css/default_style.css",
+                "style.css",
+                "https://cdnjs.cloudflare.com/ajax/libs/mathjs/3.13.3/math.js"
+                
+                
+               ],
+        "exp_id": "n_back_single_task_network",
+        "cognitive_atlas_task_id": "tsk_4a57abb949e1a",
+        "contributors": [
+                         "Patrick Bissett",
+                         "Jamie Li",
+                         "McKenzie Hagen",
+                         "Russell Poldrack"
+                        ], 
+        "time":30,
+        "reference": "http://psycnet.apa.org/journals/xlm/37/2/392/",
+        "notes": "Condition refers to whether the trial is practice or high_freq/low_freq (the two test conditions) as well as whether it was a go or SS trial",
+        "publish":"True",
+        "experiment_variables": [{
+                                 "name":"credit_var",
+                                 "type":"credit",
+                                 "datatype": "boolean",
+                                 "description":"True if avg_rt > 200"
+                                  }],
+        "deployment_variables":{"jspsych_init":
+                                        {"fullscreen": true,
+                                        "display_element": "getDisplayElement",
+                                        "on_trial_finish": "addID('n_back_single_task_network')"}
+                       			} 
+    
+   }
 ]
+

--- a/n_back_single_task_network__fmri/config.json
+++ b/n_back_single_task_network__fmri/config.json
@@ -1,51 +1,52 @@
 [
-  {
-    "name": "N-Back Single Task Network fMRI",
-    "template": "jspsych",
-    "run": [
-      "static/js/math.min.js",
-      "static/js/jspsych/jspsych.js",
-      "static/js/jspsych/plugins/jspsych-call-function.js",
-      "static/js/jspsych/plugins/jspsych-text.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-text.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-instructions.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-attention-check.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-single-stim.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-categorize.js",
-      "static/js/jspsych/plugins/jspsych-survey-text.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-stop-signal.js",
-      "static/js/utils/poldrack_fmri_utils.js",
-      "experiment.js",
-      "static/css/jspsych.css",
-      "static/css/default_style.css",
-      "style.css",
-      "https://cdnjs.cloudflare.com/ajax/libs/mathjs/3.13.3/math.js"
-    ],
-    "exp_id": "n_back_single_task_network__fmri",
-    "contributors": [
-      "Patrick Bissett",
-      "Jamie Li",
-      "McKenzie Hagen",
-      "Russell Poldrack"
-    ],
-    "time": 30,
-    "reference": "http://psycnet.apa.org/journals/xlm/37/2/392/",
-    "notes": "Condition refers to whether the trial is practice or high_freq/low_freq (the two test conditions) as well as whether it was a go or SS trial",
-    "publish": "True",
-    "experiment_variables": [
-      {
-        "name": "credit_var",
-        "type": "credit",
-        "datatype": "boolean",
-        "description": "True if avg_rt > 200"
-      }
-    ],
-    "deployment_variables": {
-      "jspsych_init": {
-        "fullscreen": true,
-        "display_element": "getDisplayElement",
-        "on_trial_finish": "addID('n_back_single_task_network__fmri')"
-      }
-    }
-  }
+    {
+        "name": "N-Back Single Task Network fMRI",
+        "template":"jspsych",
+        "run": [
+				"static/js/math.min.js",
+                "static/js/jspsych/jspsych.js",
+                "static/js/jspsych/plugins/jspsych-call-function.js",
+		        "static/js/jspsych/plugins/jspsych-text.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-text.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-instructions.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-attention-check.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-single-stim.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-categorize.js",
+                "static/js/jspsych/plugins/jspsych-survey-text.js", 
+                "static/js/jspsych/poldrack_plugins/jspsych-stop-signal.js",
+                "static/js/utils/poldrack_fmri_utils.js", 
+                "experiment.js",
+                "static/css/jspsych.css",
+                "static/css/default_style.css",
+                "style.css",
+                "https://cdnjs.cloudflare.com/ajax/libs/mathjs/3.13.3/math.js"
+                
+                
+               ],
+        "exp_id": "n_back_single_task_network__fmri",
+        "cognitive_atlas_task_id": "tsk_4a57abb949e1a",
+        "contributors": [
+                         "Patrick Bissett",
+                         "Jamie Li",
+                         "McKenzie Hagen",
+                         "Russell Poldrack"
+                        ], 
+        "time":30,
+        "reference": "http://psycnet.apa.org/journals/xlm/37/2/392/",
+        "notes": "Condition refers to whether the trial is practice or high_freq/low_freq (the two test conditions) as well as whether it was a go or SS trial",
+        "publish":"True",
+        "experiment_variables": [{
+                                 "name":"credit_var",
+                                 "type":"credit",
+                                 "datatype": "boolean",
+                                 "description":"True if avg_rt > 200"
+                                  }],
+        "deployment_variables":{"jspsych_init":
+                                        {"fullscreen": true,
+                                        "display_element": "getDisplayElement",
+                                        "on_trial_finish": "addID('n_back_single_task_network__fmri')"}
+                       			} 
+    
+   }
 ]
+

--- a/n_back_single_task_network__practice/config.json
+++ b/n_back_single_task_network__practice/config.json
@@ -1,51 +1,52 @@
 [
-  {
-    "name": "N-Back Single Task Network fMRI Practice",
-    "template": "jspsych",
-    "run": [
-      "static/js/math.min.js",
-      "static/js/jspsych/jspsych.js",
-      "static/js/jspsych/plugins/jspsych-call-function.js",
-      "static/js/jspsych/plugins/jspsych-text.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-text.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-instructions.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-attention-check.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-single-stim.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-categorize.js",
-      "static/js/jspsych/plugins/jspsych-survey-text.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-stop-signal.js",
-      "static/js/utils/poldrack_fmri_utils.js",
-      "experiment.js",
-      "static/css/jspsych.css",
-      "static/css/default_style.css",
-      "style.css",
-      "https://cdnjs.cloudflare.com/ajax/libs/mathjs/3.13.3/math.js"
-    ],
-    "exp_id": "n_back_single_task_network__practice",
-    "contributors": [
-      "Patrick Bissett",
-      "Jamie Li",
-      "McKenzie Hagen",
-      "Russell Poldrack"
-    ],
-    "time": 30,
-    "reference": "http://psycnet.apa.org/journals/xlm/37/2/392/",
-    "notes": "Condition refers to whether the trial is practice or high_freq/low_freq (the two test conditions) as well as whether it was a go or SS trial",
-    "publish": "True",
-    "experiment_variables": [
-      {
-        "name": "credit_var",
-        "type": "credit",
-        "datatype": "boolean",
-        "description": "True if avg_rt > 200"
-      }
-    ],
-    "deployment_variables": {
-      "jspsych_init": {
-        "fullscreen": true,
-        "display_element": "getDisplayElement",
-        "on_trial_finish": "addID('n_back_single_task_network__practice')"
-      }
-    }
-  }
+    {
+        "name": "N-Back Single Task Network fMRI Practice",
+        "template":"jspsych",
+        "run": [
+				"static/js/math.min.js",
+                "static/js/jspsych/jspsych.js",
+                "static/js/jspsych/plugins/jspsych-call-function.js",
+                "static/js/jspsych/plugins/jspsych-text.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-text.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-instructions.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-attention-check.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-single-stim.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-categorize.js",
+                "static/js/jspsych/plugins/jspsych-survey-text.js", 
+                "static/js/jspsych/poldrack_plugins/jspsych-stop-signal.js",
+                "static/js/utils/poldrack_fmri_utils.js", 
+                "experiment.js",
+                "static/css/jspsych.css",
+                "static/css/default_style.css",
+                "style.css",
+                "https://cdnjs.cloudflare.com/ajax/libs/mathjs/3.13.3/math.js"
+                
+                
+               ],
+        "exp_id": "n_back_single_task_network__practice",
+        "cognitive_atlas_task_id": "tsk_4a57abb949e1a",
+        "contributors": [
+                         "Patrick Bissett",
+                         "Jamie Li",
+                         "McKenzie Hagen",
+                         "Russell Poldrack"
+                        ], 
+        "time":30,
+        "reference": "http://psycnet.apa.org/journals/xlm/37/2/392/",
+        "notes": "Condition refers to whether the trial is practice or high_freq/low_freq (the two test conditions) as well as whether it was a go or SS trial",
+        "publish":"True",
+        "experiment_variables": [{
+                                 "name":"credit_var",
+                                 "type":"credit",
+                                 "datatype": "boolean",
+                                 "description":"True if avg_rt > 200"
+                                  }],
+        "deployment_variables":{"jspsych_init":
+                                        {"fullscreen": true,
+                                        "display_element": "getDisplayElement",
+                                        "on_trial_finish": "addID('n_back_single_task_network__practice')"}
+                       			} 
+    
+   }
 ]
+

--- a/n_back_with_cued_task_switching/config.json
+++ b/n_back_with_cued_task_switching/config.json
@@ -1,48 +1,49 @@
 [
-  {
-    "name": "N Back with Cued Task Switching",
-    "template": "jspsych",
-    "run": [
-      "static/js/math.min.js",
-      "static/js/jspsych/jspsych.js",
-      "static/js/jspsych/plugins/jspsych-call-function.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-text.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-instructions.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-attention-check.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-single-stim.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-categorize.js",
-      "static/js/jspsych/plugins/jspsych-survey-text.js",
-      "experiment.js",
-      "static/css/jspsych.css",
-      "static/css/default_style.css",
-      "style.css",
-      "https://cdnjs.cloudflare.com/ajax/libs/mathjs/3.13.3/math.js"
-    ],
-    "exp_id": "n_back_with_cued_task_switching",
-    "contributors": [
-      "Patrick Bissett",
-      "Jamie Li",
-      "McKenzie Hagen",
-      "Russell Poldrack"
-    ],
-    "time": 30,
-    "reference": "http://psycnet.apa.org/journals/xlm/37/2/392/",
-    "notes": "Condition refers to whether the trial is practice or high_freq/low_freq (the two test conditions) as well as whether it was a go or SS trial",
-    "publish": "True",
-    "experiment_variables": [
-      {
-        "name": "credit_var",
-        "type": "credit",
-        "datatype": "boolean",
-        "description": "True if avg_rt > 200"
-      }
-    ],
-    "deployment_variables": {
-      "jspsych_init": {
-        "fullscreen": true,
-        "display_element": "getDisplayElement",
-        "on_trial_finish": "addID('n_back_with_cued_task_switching')"
-      }
-    }
-  }
+    {
+        "name": "N Back with Cued Task Switching",
+        "template":"jspsych",
+        "run": [
+				"static/js/math.min.js",
+                "static/js/jspsych/jspsych.js",
+                "static/js/jspsych/plugins/jspsych-call-function.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-text.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-instructions.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-attention-check.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-single-stim.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-categorize.js",
+                "static/js/jspsych/plugins/jspsych-survey-text.js", 
+                "experiment.js",
+                "static/css/jspsych.css",
+                "static/css/default_style.css",
+                "style.css",
+                "https://cdnjs.cloudflare.com/ajax/libs/mathjs/3.13.3/math.js"
+                
+                
+               ],
+        "exp_id": "n_back_with_cued_task_switching",
+        "cognitive_atlas_task_id": "tsk_4a57abb949e1a",
+        "contributors": [
+                         "Patrick Bissett",
+                         "Jamie Li",
+                         "McKenzie Hagen",
+                         "Russell Poldrack"
+                        ], 
+        "time":30,
+        "reference": "http://psycnet.apa.org/journals/xlm/37/2/392/",
+        "notes": "Condition refers to whether the trial is practice or high_freq/low_freq (the two test conditions) as well as whether it was a go or SS trial",
+        "publish":"True",
+        "experiment_variables": [{
+                                 "name":"credit_var",
+                                 "type":"credit",
+                                 "datatype": "boolean",
+                                 "description":"True if avg_rt > 200"
+                                  }],
+        "deployment_variables":{"jspsych_init":
+                                        {"fullscreen": true,
+                                        "display_element": "getDisplayElement",
+                                        "on_trial_finish": "addID('n_back_with_cued_task_switching')"}
+                       			} 
+    
+   }
 ]
+

--- a/n_back_with_directed_forgetting/config.json
+++ b/n_back_with_directed_forgetting/config.json
@@ -1,48 +1,49 @@
 [
-  {
-    "name": "N Back with Directed Forgetting",
-    "template": "jspsych",
-    "run": [
-      "static/js/math.min.js",
-      "static/js/jspsych/jspsych.js",
-      "static/js/jspsych/plugins/jspsych-call-function.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-text.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-instructions.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-attention-check.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-single-stim.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-categorize.js",
-      "static/js/jspsych/plugins/jspsych-survey-text.js",
-      "experiment.js",
-      "static/css/jspsych.css",
-      "static/css/default_style.css",
-      "style.css",
-      "https://cdnjs.cloudflare.com/ajax/libs/mathjs/3.13.3/math.js"
-    ],
-    "exp_id": "n_back_with_directed_forgetting",
-    "contributors": [
-      "Patrick Bissett",
-      "Jamie Li",
-      "McKenzie Hagen",
-      "Russell Poldrack"
-    ],
-    "time": 30,
-    "reference": "http://psycnet.apa.org/journals/xlm/37/2/392/",
-    "notes": "Condition refers to whether the trial is practice or high_freq/low_freq (the two test conditions) as well as whether it was a go or SS trial",
-    "publish": "True",
-    "experiment_variables": [
-      {
-        "name": "credit_var",
-        "type": "credit",
-        "datatype": "boolean",
-        "description": "True if avg_rt > 200"
-      }
-    ],
-    "deployment_variables": {
-      "jspsych_init": {
-        "fullscreen": true,
-        "display_element": "getDisplayElement",
-        "on_trial_finish": "addID('n_back_with_directed_forgetting')"
-      }
-    }
-  }
+    {
+        "name": "N Back with Directed Forgetting",
+        "template":"jspsych",
+        "run": [
+				"static/js/math.min.js",
+                "static/js/jspsych/jspsych.js",
+                "static/js/jspsych/plugins/jspsych-call-function.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-text.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-instructions.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-attention-check.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-single-stim.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-categorize.js",
+                "static/js/jspsych/plugins/jspsych-survey-text.js", 
+                "experiment.js",
+                "static/css/jspsych.css",
+                "static/css/default_style.css",
+                "style.css",
+                "https://cdnjs.cloudflare.com/ajax/libs/mathjs/3.13.3/math.js"
+                
+                
+               ],
+        "exp_id": "n_back_with_directed_forgetting",
+        "cognitive_atlas_task_id": "tsk_4a57abb949e1a",
+        "contributors": [
+                         "Patrick Bissett",
+                         "Jamie Li",
+                         "McKenzie Hagen",
+                         "Russell Poldrack"
+                        ], 
+        "time":30,
+        "reference": "http://psycnet.apa.org/journals/xlm/37/2/392/",
+        "notes": "Condition refers to whether the trial is practice or high_freq/low_freq (the two test conditions) as well as whether it was a go or SS trial",
+        "publish":"True",
+        "experiment_variables": [{
+                                 "name":"credit_var",
+                                 "type":"credit",
+                                 "datatype": "boolean",
+                                 "description":"True if avg_rt > 200"
+                                  }],
+        "deployment_variables":{"jspsych_init":
+                                        {"fullscreen": true,
+                                        "display_element": "getDisplayElement",
+                                        "on_trial_finish": "addID('n_back_with_directed_forgetting')"}
+                       			} 
+    
+   }
 ]
+

--- a/n_back_with_flanker/config.json
+++ b/n_back_with_flanker/config.json
@@ -1,46 +1,48 @@
 [
-  {
-    "name": "N Back with Flanker",
-    "template": "jspsych",
-    "run": [
-      "static/js/jspsych/jspsych.js",
-      "static/js/jspsych/plugins/jspsych-call-function.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-text.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-instructions.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-attention-check.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-single-stim.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-categorize.js",
-      "static/js/jspsych/plugins/jspsych-survey-text.js",
-      "experiment.js",
-      "static/css/jspsych.css",
-      "static/css/default_style.css",
-      "style.css",
-      "https://cdnjs.cloudflare.com/ajax/libs/mathjs/3.13.3/math.js"
-    ],
-    "exp_id": "n_back_with_flanker",
-    "contributors": [
-      "Jamie Li",
-      "Patrick Bissett",
-      "Russell Poldrack"
-    ],
-    "time": 30,
-    "reference": "http://psycnet.apa.org/journals/xlm/37/2/392/",
-    "notes": "Condition refers to whether the trial is practice or high_freq/low_freq (the two test conditions) as well as whether it was a go or SS trial",
-    "publish": "True",
-    "experiment_variables": [
-      {
-        "name": "credit_var",
-        "type": "credit",
-        "datatype": "boolean",
-        "description": "True if avg_rt > 200"
-      }
-    ],
-    "deployment_variables": {
-      "jspsych_init": {
-        "fullscreen": true,
-        "display_element": "getDisplayElement",
-        "on_trial_finish": "addID('n_back_with_flanker')"
-      }
-    }
-  }
+    {
+        "name": "N Back with Flanker",
+        "template":"jspsych",
+        "run": [
+
+                "static/js/jspsych/jspsych.js",
+                "static/js/jspsych/plugins/jspsych-call-function.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-text.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-instructions.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-attention-check.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-single-stim.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-categorize.js",
+                "static/js/jspsych/plugins/jspsych-survey-text.js", 
+                "experiment.js",
+                "static/css/jspsych.css",
+                "static/css/default_style.css",
+                "style.css",
+                "https://cdnjs.cloudflare.com/ajax/libs/mathjs/3.13.3/math.js"
+                
+                
+               ],
+        "exp_id": "n_back_with_flanker",
+        "cognitive_atlas_task_id": "tsk_4a57abb949e1a",
+        "contributors": [
+                         "Jamie Li",
+                         "Patrick Bissett",
+                         "Russell Poldrack"
+                        ], 
+        "time":30,
+        "reference": "http://psycnet.apa.org/journals/xlm/37/2/392/",
+        "notes": "Condition refers to whether the trial is practice or high_freq/low_freq (the two test conditions) as well as whether it was a go or SS trial",
+        "publish":"True",
+        "experiment_variables": [{
+                                 "name":"credit_var",
+                                 "type":"credit",
+                                 "datatype": "boolean",
+                                 "description":"True if avg_rt > 200"
+                                  }],
+        "deployment_variables":{"jspsych_init":
+                                        {"fullscreen": true,
+                                        "display_element": "getDisplayElement",
+                                        "on_trial_finish": "addID('n_back_with_flanker')"}
+                       			} 
+    
+   }
 ]
+

--- a/n_back_with_predictable_task_switching/config.json
+++ b/n_back_with_predictable_task_switching/config.json
@@ -1,48 +1,49 @@
 [
-  {
-    "name": "N Back with Predictable Task Switching",
-    "template": "jspsych",
-    "run": [
-      "static/js/math.min.js",
-      "static/js/jspsych/jspsych.js",
-      "static/js/jspsych/plugins/jspsych-call-function.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-text.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-instructions.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-attention-check.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-single-stim.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-categorize.js",
-      "static/js/jspsych/plugins/jspsych-survey-text.js",
-      "experiment.js",
-      "static/css/jspsych.css",
-      "static/css/default_style.css",
-      "style.css",
-      "https://cdnjs.cloudflare.com/ajax/libs/mathjs/3.13.3/math.js"
-    ],
-    "exp_id": "n_back_with_predictable_task_switching",
-    "contributors": [
-      "Patrick Bissett",
-      "Jamie Li",
-      "McKenzie Hagen",
-      "Russell Poldrack"
-    ],
-    "time": 30,
-    "reference": "http://psycnet.apa.org/journals/xlm/37/2/392/",
-    "notes": "Condition refers to whether the trial is practice or high_freq/low_freq (the two test conditions) as well as whether it was a go or SS trial",
-    "publish": "True",
-    "experiment_variables": [
-      {
-        "name": "credit_var",
-        "type": "credit",
-        "datatype": "boolean",
-        "description": "True if avg_rt > 200"
-      }
-    ],
-    "deployment_variables": {
-      "jspsych_init": {
-        "fullscreen": true,
-        "display_element": "getDisplayElement",
-        "on_trial_finish": "addID('n_back_with_predictable_task_switching')"
-      }
-    }
-  }
+    {
+        "name": "N Back with Predictable Task Switching",
+        "template":"jspsych",
+        "run": [
+				"static/js/math.min.js",
+                "static/js/jspsych/jspsych.js",
+                "static/js/jspsych/plugins/jspsych-call-function.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-text.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-instructions.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-attention-check.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-single-stim.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-categorize.js",
+                "static/js/jspsych/plugins/jspsych-survey-text.js", 
+                "experiment.js",
+                "static/css/jspsych.css",
+                "static/css/default_style.css",
+                "style.css",
+                "https://cdnjs.cloudflare.com/ajax/libs/mathjs/3.13.3/math.js"
+                
+                
+               ],
+        "exp_id": "n_back_with_predictable_task_switching",
+        "cognitive_atlas_task_id": "tsk_4a57abb949e1a",
+        "contributors": [
+                         "Patrick Bissett",
+                         "Jamie Li",
+                         "McKenzie Hagen",
+                         "Russell Poldrack"
+                        ], 
+        "time":30,
+        "reference": "http://psycnet.apa.org/journals/xlm/37/2/392/",
+        "notes": "Condition refers to whether the trial is practice or high_freq/low_freq (the two test conditions) as well as whether it was a go or SS trial",
+        "publish":"True",
+        "experiment_variables": [{
+                                 "name":"credit_var",
+                                 "type":"credit",
+                                 "datatype": "boolean",
+                                 "description":"True if avg_rt > 200"
+                                  }],
+        "deployment_variables":{"jspsych_init":
+                                        {"fullscreen": true,
+                                        "display_element": "getDisplayElement",
+                                        "on_trial_finish": "addID('n_back_with_predictable_task_switching')"}
+                       			} 
+    
+   }
 ]
+

--- a/n_back_with_shape_matching/config.json
+++ b/n_back_with_shape_matching/config.json
@@ -1,48 +1,49 @@
 [
-  {
-    "name": "N Back with Shape Matching",
-    "template": "jspsych",
-    "run": [
-      "static/js/math.min.js",
-      "static/js/jspsych/jspsych.js",
-      "static/js/jspsych/plugins/jspsych-call-function.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-text.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-instructions.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-attention-check.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-single-stim.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-categorize.js",
-      "static/js/jspsych/plugins/jspsych-survey-text.js",
-      "experiment.js",
-      "static/css/jspsych.css",
-      "static/css/default_style.css",
-      "style.css",
-      "https://cdnjs.cloudflare.com/ajax/libs/mathjs/3.13.3/math.js"
-    ],
-    "exp_id": "n_back_with_shape_matching",
-    "contributors": [
-      "Patrick Bissett",
-      "Jamie Li",
-      "McKenzie Hagen",
-      "Russell Poldrack"
-    ],
-    "time": 30,
-    "reference": "http://psycnet.apa.org/journals/xlm/37/2/392/",
-    "notes": "Condition refers to whether the trial is practice or high_freq/low_freq (the two test conditions) as well as whether it was a go or SS trial",
-    "publish": "True",
-    "experiment_variables": [
-      {
-        "name": "credit_var",
-        "type": "credit",
-        "datatype": "boolean",
-        "description": "True if avg_rt > 200"
-      }
-    ],
-    "deployment_variables": {
-      "jspsych_init": {
-        "fullscreen": true,
-        "display_element": "getDisplayElement",
-        "on_trial_finish": "addID('n_back_with_shape_matching')"
-      }
-    }
-  }
+    {
+        "name": "N Back with Shape Matching",
+        "template":"jspsych",
+        "run": [
+				"static/js/math.min.js",
+                "static/js/jspsych/jspsych.js",
+                "static/js/jspsych/plugins/jspsych-call-function.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-text.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-instructions.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-attention-check.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-single-stim.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-categorize.js",
+                "static/js/jspsych/plugins/jspsych-survey-text.js", 
+                "experiment.js",
+                "static/css/jspsych.css",
+                "static/css/default_style.css",
+                "style.css",
+                "https://cdnjs.cloudflare.com/ajax/libs/mathjs/3.13.3/math.js"
+                
+                
+               ],
+        "exp_id": "n_back_with_shape_matching",
+        "cognitive_atlas_task_id": "tsk_4a57abb949e1a",
+        "contributors": [
+                         "Patrick Bissett",
+                         "Jamie Li",
+                         "McKenzie Hagen",
+                         "Russell Poldrack"
+                        ], 
+        "time":30,
+        "reference": "http://psycnet.apa.org/journals/xlm/37/2/392/",
+        "notes": "Condition refers to whether the trial is practice or high_freq/low_freq (the two test conditions) as well as whether it was a go or SS trial",
+        "publish":"True",
+        "experiment_variables": [{
+                                 "name":"credit_var",
+                                 "type":"credit",
+                                 "datatype": "boolean",
+                                 "description":"True if avg_rt > 200"
+                                  }],
+        "deployment_variables":{"jspsych_init":
+                                        {"fullscreen": true,
+                                        "display_element": "getDisplayElement",
+                                        "on_trial_finish": "addID('n_back_with_shape_matching')"}
+                       			} 
+    
+   }
 ]
+

--- a/network_traversal/config.json
+++ b/network_traversal/config.json
@@ -1,44 +1,42 @@
 [
-  {
-    "name": "Images Experiment",
-    "template": "jspsych",
-    "run": [
-      "static/js/jspsych/jspsych.js",
-      "static/js/jspsych/plugins/jspsych-text.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-text.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-instructions.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-single-stim.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-categorize.js",
-      "static/js/jspsych/plugins/jspsych-single-audio.js",
-      "static/js/jspsych/plugins/jspsych-survey-text.js",
-      "static/js/utils/poldrack_utils.js",
-      "experiment.js",
-      "static/css/jspsych.css",
-      "static/css/default_style.css",
-      "style.css"
-    ],
-    "exp_id": "network_traversal",
-    "contributors": [
-      "Jon Walters"
-    ],
-    "time": 1,
-    "reference": "Karuza et al., 2017",
-    "notes": "None",
-    "publish": "True",
-    "experiment_variables": [
-      {
-        "name": "credit_var",
-        "type": "credit",
-        "datatype": "boolean",
-        "description": "True if complete"
-      }
-    ],
-    "deployment_variables": {
-      "jspsych_init": {
-        "fullscreen": true,
-        "display_element": "getDisplayElement",
-        "on_trial_finish": "addID('network_traversal')"
-      }
-    }
-  }
+    {
+        "name": "Images Experiment",
+        "template": "jspsych",
+        "run": [
+                "static/js/jspsych/jspsych.js",
+                "static/js/jspsych/plugins/jspsych-text.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-text.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-instructions.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-single-stim.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-categorize.js",
+                "static/js/jspsych/plugins/jspsych-single-audio.js",
+                "static/js/jspsych/plugins/jspsych-survey-text.js",
+                "static/js/utils/poldrack_utils.js",
+                "experiment.js",
+                "static/css/jspsych.css",
+                "static/css/default_style.css",
+                "style.css"
+               ],
+        "exp_id": "network_traversal",
+        "cognitive_atlas_task_id": "tsk_4a57abb949e1a",
+        "contributors": [
+                         "Jon Walters"
+                        ], 
+        "time":1,
+        "reference": "Karuza et al., 2017",
+        "notes": "None",
+        "publish": "True",
+        "experiment_variables": [{
+                                 "name":"credit_var",
+                                 "type":"credit",
+                                 "datatype": "boolean",
+                                 "description":"True if complete"
+                                  }],
+        "deployment_variables":{"jspsych_init":
+                                        {"fullscreen": true,
+                                        "display_element": "getDisplayElement",
+                                        "on_trial_finish": "addID('network_traversal')"}
+                       }
+    
+   }
 ]

--- a/network_traversal_eulerian_0/config.json
+++ b/network_traversal_eulerian_0/config.json
@@ -1,44 +1,42 @@
 [
-  {
-    "name": "Network Traversal Eulerian",
-    "template": "jspsych",
-    "run": [
-      "static/js/jspsych/jspsych.js",
-      "static/js/jspsych/plugins/jspsych-text.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-text.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-instructions.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-single-stim.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-categorize.js",
-      "static/js/jspsych/plugins/jspsych-single-audio.js",
-      "static/js/jspsych/plugins/jspsych-survey-text.js",
-      "static/js/utils/poldrack_utils.js",
-      "experiment.js",
-      "static/css/jspsych.css",
-      "static/css/default_style.css",
-      "style.css"
-    ],
-    "exp_id": "network_traversal_eulerian_0",
-    "contributors": [
-      "Jon Walters"
-    ],
-    "time": 1,
-    "reference": "Karuza et al., 2017",
-    "notes": "None",
-    "publish": "True",
-    "experiment_variables": [
-      {
-        "name": "credit_var",
-        "type": "credit",
-        "datatype": "boolean",
-        "description": "True if complete"
-      }
-    ],
-    "deployment_variables": {
-      "jspsych_init": {
-        "fullscreen": true,
-        "display_element": "getDisplayElement",
-        "on_trial_finish": "addID('network_traversal_eulerian_0')"
-      }
-    }
-  }
+    {
+        "name": "Network Traversal Eulerian",
+        "template": "jspsych",
+        "run": [
+                "static/js/jspsych/jspsych.js",
+                "static/js/jspsych/plugins/jspsych-text.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-text.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-instructions.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-single-stim.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-categorize.js",
+                "static/js/jspsych/plugins/jspsych-single-audio.js",
+                "static/js/jspsych/plugins/jspsych-survey-text.js",
+                "static/js/utils/poldrack_utils.js",
+                "experiment.js",
+                "static/css/jspsych.css",
+                "static/css/default_style.css",
+                "style.css"
+               ],
+        "exp_id": "network_traversal_eulerian_0",
+        "cognitive_atlas_task_id": "tsk_4a57abb949e1a",
+        "contributors": [
+                         "Jon Walters"
+                        ], 
+        "time":1,
+        "reference": "Karuza et al., 2017",
+        "notes": "None",
+        "publish": "True",
+        "experiment_variables": [{
+                                 "name":"credit_var",
+                                 "type":"credit",
+                                 "datatype": "boolean",
+                                 "description":"True if complete"
+                                  }],
+        "deployment_variables":{"jspsych_init":
+                                        {"fullscreen": true,
+                                        "display_element": "getDisplayElement",
+                                        "on_trial_finish": "addID('network_traversal_eulerian_0')"}
+                       }
+    
+   }
 ]

--- a/network_traversal_hamiltonian_0/config.json
+++ b/network_traversal_hamiltonian_0/config.json
@@ -1,44 +1,42 @@
 [
-  {
-    "name": "Network Traversal Hamiltonian",
-    "template": "jspsych",
-    "run": [
-      "static/js/jspsych/jspsych.js",
-      "static/js/jspsych/plugins/jspsych-text.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-text.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-instructions.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-single-stim.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-categorize.js",
-      "static/js/jspsych/plugins/jspsych-single-audio.js",
-      "static/js/jspsych/plugins/jspsych-survey-text.js",
-      "static/js/utils/poldrack_utils.js",
-      "experiment.js",
-      "static/css/jspsych.css",
-      "static/css/default_style.css",
-      "style.css"
-    ],
-    "exp_id": "network_traversal_hamiltonian_0",
-    "contributors": [
-      "Jon Walters"
-    ],
-    "time": 1,
-    "reference": "Karuza et al., 2017",
-    "notes": "None",
-    "publish": "True",
-    "experiment_variables": [
-      {
-        "name": "credit_var",
-        "type": "credit",
-        "datatype": "boolean",
-        "description": "True if complete"
-      }
-    ],
-    "deployment_variables": {
-      "jspsych_init": {
-        "fullscreen": true,
-        "display_element": "getDisplayElement",
-        "on_trial_finish": "addID('network_traversal_hamiltonian_0')"
-      }
-    }
-  }
+    {
+        "name": "Network Traversal Hamiltonian",
+        "template": "jspsych",
+        "run": [
+                "static/js/jspsych/jspsych.js",
+                "static/js/jspsych/plugins/jspsych-text.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-text.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-instructions.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-single-stim.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-categorize.js",
+                "static/js/jspsych/plugins/jspsych-single-audio.js",
+                "static/js/jspsych/plugins/jspsych-survey-text.js",
+                "static/js/utils/poldrack_utils.js",
+                "experiment.js",
+                "static/css/jspsych.css",
+                "static/css/default_style.css",
+                "style.css"
+               ],
+        "exp_id": "network_traversal_hamiltonian_0",
+        "cognitive_atlas_task_id": "tsk_4a57abb949e1a",
+        "contributors": [
+                         "Jon Walters"
+                        ], 
+        "time":1,
+        "reference": "Karuza et al., 2017",
+        "notes": "None",
+        "publish": "True",
+        "experiment_variables": [{
+                                 "name":"credit_var",
+                                 "type":"credit",
+                                 "datatype": "boolean",
+                                 "description":"True if complete"
+                                  }],
+        "deployment_variables":{"jspsych_init":
+                                        {"fullscreen": true,
+                                        "display_element": "getDisplayElement",
+                                        "on_trial_finish": "addID('network_traversal_hamiltonian_0')"}
+                       }
+    
+   }
 ]

--- a/network_traversal_random_0/config.json
+++ b/network_traversal_random_0/config.json
@@ -1,44 +1,42 @@
 [
-  {
-    "name": "Network Traversal Random",
-    "template": "jspsych",
-    "run": [
-      "static/js/jspsych/jspsych.js",
-      "static/js/jspsych/plugins/jspsych-text.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-text.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-instructions.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-single-stim.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-categorize.js",
-      "static/js/jspsych/plugins/jspsych-single-audio.js",
-      "static/js/jspsych/plugins/jspsych-survey-text.js",
-      "static/js/utils/poldrack_utils.js",
-      "experiment.js",
-      "static/css/jspsych.css",
-      "static/css/default_style.css",
-      "style.css"
-    ],
-    "exp_id": "network_traversal_random_0",
-    "contributors": [
-      "Jon Walters"
-    ],
-    "time": 1,
-    "reference": "Karuza et al., 2017",
-    "notes": "None",
-    "publish": "True",
-    "experiment_variables": [
-      {
-        "name": "credit_var",
-        "type": "credit",
-        "datatype": "boolean",
-        "description": "True if complete"
-      }
-    ],
-    "deployment_variables": {
-      "jspsych_init": {
-        "fullscreen": true,
-        "display_element": "getDisplayElement",
-        "on_trial_finish": "addID('network_traversal_random_0')"
-      }
-    }
-  }
+    {
+        "name": "Network Traversal Random",
+        "template": "jspsych",
+        "run": [
+                "static/js/jspsych/jspsych.js",
+                "static/js/jspsych/plugins/jspsych-text.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-text.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-instructions.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-single-stim.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-categorize.js",
+                "static/js/jspsych/plugins/jspsych-single-audio.js",
+                "static/js/jspsych/plugins/jspsych-survey-text.js",
+                "static/js/utils/poldrack_utils.js",
+                "experiment.js",
+                "static/css/jspsych.css",
+                "static/css/default_style.css",
+                "style.css"
+               ],
+        "exp_id": "network_traversal_random_0",
+        "cognitive_atlas_task_id": "tsk_4a57abb949e1a",
+        "contributors": [
+                         "Jon Walters"
+                        ], 
+        "time":1,
+        "reference": "Karuza et al., 2017",
+        "notes": "None",
+        "publish": "True",
+        "experiment_variables": [{
+                                 "name":"credit_var",
+                                 "type":"credit",
+                                 "datatype": "boolean",
+                                 "description":"True if complete"
+                                  }],
+        "deployment_variables":{"jspsych_init":
+                                        {"fullscreen": true,
+                                        "display_element": "getDisplayElement",
+                                        "on_trial_finish": "addID('network_traversal_random_0')"}
+                       }
+    
+   }
 ]

--- a/network_traversal_re/config.json
+++ b/network_traversal_re/config.json
@@ -1,44 +1,42 @@
 [
-  {
-    "name": "Images Experiment (re)",
-    "template": "jspsych",
-    "run": [
-      "static/js/jspsych/jspsych.js",
-      "static/js/jspsych/plugins/jspsych-text.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-text.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-instructions.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-single-stim.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-categorize.js",
-      "static/js/jspsych/plugins/jspsych-single-audio.js",
-      "static/js/jspsych/plugins/jspsych-survey-text.js",
-      "static/js/utils/poldrack_utils.js",
-      "experiment.js",
-      "static/css/jspsych.css",
-      "static/css/default_style.css",
-      "style.css"
-    ],
-    "exp_id": "network_traversal_re",
-    "contributors": [
-      "Jon Walters"
-    ],
-    "time": 1,
-    "reference": "Karuza et al., 2017",
-    "notes": "None",
-    "publish": "True",
-    "experiment_variables": [
-      {
-        "name": "credit_var",
-        "type": "credit",
-        "datatype": "boolean",
-        "description": "True if complete"
-      }
-    ],
-    "deployment_variables": {
-      "jspsych_init": {
-        "fullscreen": true,
-        "display_element": "getDisplayElement",
-        "on_trial_finish": "addID('network_traversal_re')"
-      }
-    }
-  }
+    {
+        "name": "Images Experiment (re)",
+        "template": "jspsych",
+        "run": [
+                "static/js/jspsych/jspsych.js",
+                "static/js/jspsych/plugins/jspsych-text.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-text.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-instructions.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-single-stim.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-categorize.js",
+                "static/js/jspsych/plugins/jspsych-single-audio.js",
+                "static/js/jspsych/plugins/jspsych-survey-text.js",
+                "static/js/utils/poldrack_utils.js",
+                "experiment.js",
+                "static/css/jspsych.css",
+                "static/css/default_style.css",
+                "style.css"
+               ],
+        "exp_id": "network_traversal_re",
+        "cognitive_atlas_task_id": "tsk_4a57abb949e1a",
+        "contributors": [
+                         "Jon Walters"
+                        ], 
+        "time":1,
+        "reference": "Karuza et al., 2017",
+        "notes": "None",
+        "publish": "True",
+        "experiment_variables": [{
+                                 "name":"credit_var",
+                                 "type":"credit",
+                                 "datatype": "boolean",
+                                 "description":"True if complete"
+                                  }],
+        "deployment_variables":{"jspsych_init":
+                                        {"fullscreen": true,
+                                        "display_element": "getDisplayElement",
+                                        "on_trial_finish": "addID('network_traversal_re')"}
+                       }
+    
+   }
 ]

--- a/number_letter/config.json
+++ b/number_letter/config.json
@@ -1,39 +1,39 @@
 [
-  {
-    "name": "Number-Letter",
-    "template": "jspsych",
-    "run": [
-      "static/js/jspsych/jspsych.js",
-      "static/js/jspsych/plugins/jspsych-text.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-text.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-instructions.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-attention-check.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-single-stim.js",
-      "static/js/jspsych/plugins/jspsych-survey-text.js",
-      "static/js/utils/poldrack_utils.js",
-      "experiment.js",
-      "static/css/jspsych.css",
-      "static/css/default_style.css",
-      "style.css"
-    ],
-    "exp_id": "number_letter",
-    "contributors": [
-      "Ian Eisenberg",
-      "Zeynep Enkavi",
-      "Patrick Bissett",
-      "Vanessa Sochat",
-      "Russell Poldrack"
-    ],
-    "time": 5,
-    "reference": "http://www.sciencedirect.com/science/article/pii/S001002859990734X",
-    "notes": "condition indicates block (which task, or rotateswitch block) and trial_id indicates stimulus position",
-    "publish": "True",
-    "deployment_variables": {
-      "jspsych_init": {
-        "fullscreen": true,
-        "display_element": "getDisplayElement",
-        "on_trial_finish": "addID('number_letter')"
-      }
-    }
-  }
+    {
+        "name": "Number-Letter",
+        "template":"jspsych",
+        "run": [
+                "static/js/jspsych/jspsych.js",
+                "static/js/jspsych/plugins/jspsych-text.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-text.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-instructions.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-attention-check.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-single-stim.js",
+                "static/js/jspsych/plugins/jspsych-survey-text.js",
+                "static/js/utils/poldrack_utils.js",
+                "experiment.js",
+                "static/css/jspsych.css",
+                "static/css/default_style.css",
+                "style.css"
+               ],
+        "exp_id": "number_letter",
+        "cognitive_atlas_task_id": "trm_4c3e0a9576c3b",
+        "contributors": [
+                         "Ian Eisenberg",
+                         "Zeynep Enkavi",
+                         "Patrick Bissett",
+                         "Vanessa Sochat",
+                         "Russell Poldrack"
+                        ], 
+        "time":5,
+        "reference": "http://www.sciencedirect.com/science/article/pii/S001002859990734X",
+        "notes": "condition indicates block (which task, or rotateswitch block) and trial_id indicates stimulus position",
+        "publish":"True",
+        "deployment_variables":{"jspsych_init":
+                                        {"fullscreen": true,
+                                        "display_element": "getDisplayElement",
+                                        "on_trial_finish": "addID('number_letter')"}
+                       } 
+   }
 ]
+

--- a/object_rating/config.json
+++ b/object_rating/config.json
@@ -1,50 +1,52 @@
 [
-  {
-    "name": "Object Rating",
-    "template": "jspsych",
-    "run": [
-      "static/js/jspsych/jspsych.js",
-      "static/js/jspsych/plugins/jspsych-call-function.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-text.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-instructions.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-attention-check.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-single-stim.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-categorize.js",
-      "static/js/jspsych/plugins/jspsych-survey-text.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-stop-signal.js",
-      "static/css/jspsych.css",
-      "static/css/default_style.css",
-      "style.css",
-      "neutral_pics.js",
-      "experiment.js"
-    ],
-    "exp_id": "object_rating",
-    "contributors": [
-      "Jamie Li",
-      "Ian Eisenberg",
-      "Patrick Bissett",
-      "Zeynep Enkavi",
-      "Sadiv Parikh",
-      "Russell Poldrack"
-    ],
-    "time": 30,
-    "reference": "http://psycnet.apa.org/journals/xlm/37/2/392/",
-    "notes": "Condition refers to whether the trial is practice or high_freq/low_freq (the two test conditions) as well as whether it was a go or SS trial",
-    "publish": "True",
-    "experiment_variables": [
-      {
-        "name": "credit_var",
-        "type": "credit",
-        "datatype": "boolean",
-        "description": "True if avg_rt > 200"
-      }
-    ],
-    "deployment_variables": {
-      "jspsych_init": {
-        "fullscreen": true,
-        "display_element": "getDisplayElement",
-        "on_trial_finish": "addID()"
-      }
-    }
-  }
+    {
+        "name": "Object Rating",
+        "template":"jspsych",
+        "run": [
+
+                "static/js/jspsych/jspsych.js",
+                "static/js/jspsych/plugins/jspsych-call-function.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-text.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-instructions.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-attention-check.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-single-stim.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-categorize.js",
+                "static/js/jspsych/plugins/jspsych-survey-text.js", 
+                "static/js/jspsych/poldrack_plugins/jspsych-stop-signal.js",
+                "static/css/jspsych.css",
+                "static/css/default_style.css",
+                "style.css",
+                "neutral_pics.js",
+                "experiment.js"
+                
+                
+               ],
+        "exp_id": "object_rating",
+        "cognitive_atlas_task_id": "tsk_4a57abb949e1a",
+        "contributors": [
+                         "Jamie Li",
+                         "Ian Eisenberg",
+                         "Patrick Bissett",
+                         "Zeynep Enkavi",
+                         "Sadiv Parikh",
+                         "Russell Poldrack"
+                        ], 
+        "time":30,
+        "reference": "http://psycnet.apa.org/journals/xlm/37/2/392/",
+        "notes": "Condition refers to whether the trial is practice or high_freq/low_freq (the two test conditions) as well as whether it was a go or SS trial",
+        "publish":"True",
+        "experiment_variables": [{
+                                 "name":"credit_var",
+                                 "type":"credit",
+                                 "datatype": "boolean",
+                                 "description":"True if avg_rt > 200"
+                                  }],
+        "deployment_variables":{"jspsych_init":
+                                        {"fullscreen": true,
+                                        "display_element": "getDisplayElement",
+                                        "on_trial_finish": "addID()"}
+                       			} 
+    
+   }
 ]
+

--- a/object_recognition/config.json
+++ b/object_recognition/config.json
@@ -1,42 +1,41 @@
 [
-  {
-    "name": "Object Recognition Network",
-    "template": "jspsych",
-    "run": [
-      "static/js/math.min.js",
-      "static/js/jspsych/jspsych.js",
-      "static/js/jspsych/plugins/jspsych-text.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-text.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-instructions.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-attention-check.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-single-stim.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-multi-stim-multi-response.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-single-stim-button.js",
-      "static/js/jspsych/plugins/jspsych-survey-text.js",
-      "static/js/jspsych/plugins/jspsych-call-function.js",
-      "static/js/utils/poldrack_utils.js",
-      "experiment.js",
-      "static/css/jspsych.css",
-      "static/css/default_style.css",
-      "object_recognition_style.css"
-    ],
-    "exp_id": "object_recognition",
-    "contributors": [
-      "Ian Eisenberg",
-      "Zeynep Enkavi",
-      "Patrick Bissett",
-      "Vanessa Sochat",
-      "Russell Poldrack"
-    ],
-    "time": 7,
-    "reference": "http://www.ncbi.nlm.nih.gov/pmc/articles/PMC2978794/",
-    "publish": "True",
-    "deployment_variables": {
-      "jspsych_init": {
-        "fullscreen": true,
-        "display_element": "getDisplayElement",
-        "on_trial_finish": "addID('object_recognition')"
-      }
-    }
-  }
+    {
+        "name": "Object Recognition Network",
+        "template":"jspsych",
+        "run": [
+        		"static/js/math.min.js",
+                "static/js/jspsych/jspsych.js",
+                "static/js/jspsych/plugins/jspsych-text.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-text.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-instructions.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-attention-check.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-single-stim.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-multi-stim-multi-response.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-single-stim-button.js",
+                "static/js/jspsych/plugins/jspsych-survey-text.js",
+                "static/js/jspsych/plugins/jspsych-call-function.js",
+                "static/js/utils/poldrack_utils.js",
+                "experiment.js",
+                "static/css/jspsych.css",
+                "static/css/default_style.css",
+                "object_recognition_style.css"
+               ],
+        "exp_id": "object_recognition",
+        "cognitive_atlas_task_id": "tsk_4a57abb949a0d",
+        "contributors": [
+                         "Ian Eisenberg",
+                         "Zeynep Enkavi",
+                         "Patrick Bissett",
+                         "Vanessa Sochat",
+                         "Russell Poldrack"
+                        ], 
+        "time": 7,
+        "reference": "http://www.ncbi.nlm.nih.gov/pmc/articles/PMC2978794/",
+        "publish":"True",
+        "deployment_variables":{"jspsych_init":
+                                        {"fullscreen": true,
+                                        "display_element": "getDisplayElement",
+                                        "on_trial_finish": "addID('object_recognition')"}
+                       }
+   }
 ]

--- a/post_task_eating_abstinence_self_report/config.json
+++ b/post_task_eating_abstinence_self_report/config.json
@@ -1,49 +1,51 @@
 [
-  {
-    "name": "Post-Task Eating Abstinence Self-Report",
-    "template": "jspsych",
-    "run": [
-      "static/js/jspsych/jspsych.js",
-      "static/js/jspsych/plugins/jspsych-call-function.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-text.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-instructions.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-attention-check.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-single-stim.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-categorize.js",
-      "static/js/jspsych/plugins/jspsych-survey-text.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-stop-signal.js",
-      "static/css/jspsych.css",
-      "static/css/default_style.css",
-      "style.css",
-      "experiment.js"
-    ],
-    "exp_id": "post_task_eating_abstinence_self_report",
-    "contributors": [
-      "Jamie Li",
-      "Ian Eisenberg",
-      "Patrick Bissett",
-      "Zeynep Enkavi",
-      "Sadiv Parikh",
-      "Russell Poldrack"
-    ],
-    "time": 30,
-    "reference": "http://psycnet.apa.org/journals/xlm/37/2/392/",
-    "notes": "Condition refers to whether the trial is practice or high_freq/low_freq (the two test conditions) as well as whether it was a go or SS trial",
-    "publish": "True",
-    "experiment_variables": [
-      {
-        "name": "credit_var",
-        "type": "credit",
-        "datatype": "boolean",
-        "description": "True if avg_rt > 200"
-      }
-    ],
-    "deployment_variables": {
-      "jspsych_init": {
-        "fullscreen": true,
-        "display_element": "getDisplayElement",
-        "on_trial_finish": "addID()"
-      }
-    }
-  }
+    {
+        "name": "Post-Task Eating Abstinence Self-Report",
+        "template":"jspsych",
+        "run": [
+
+                "static/js/jspsych/jspsych.js",
+                "static/js/jspsych/plugins/jspsych-call-function.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-text.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-instructions.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-attention-check.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-single-stim.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-categorize.js",
+                "static/js/jspsych/plugins/jspsych-survey-text.js", 
+                "static/js/jspsych/poldrack_plugins/jspsych-stop-signal.js",
+                "static/css/jspsych.css",
+                "static/css/default_style.css",
+                "style.css",
+                "experiment.js"
+                
+                
+               ],
+        "exp_id": "post_task_eating_abstinence_self_report",
+        "cognitive_atlas_task_id": "tsk_4a57abb949e1a",
+        "contributors": [
+                         "Jamie Li",
+                         "Ian Eisenberg",
+                         "Patrick Bissett",
+                         "Zeynep Enkavi",
+                         "Sadiv Parikh",
+                         "Russell Poldrack"
+                        ], 
+        "time":30,
+        "reference": "http://psycnet.apa.org/journals/xlm/37/2/392/",
+        "notes": "Condition refers to whether the trial is practice or high_freq/low_freq (the two test conditions) as well as whether it was a go or SS trial",
+        "publish":"True",
+        "experiment_variables": [{
+                                 "name":"credit_var",
+                                 "type":"credit",
+                                 "datatype": "boolean",
+                                 "description":"True if avg_rt > 200"
+                                  }],
+        "deployment_variables":{"jspsych_init":
+                                        {"fullscreen": true,
+                                        "display_element": "getDisplayElement",
+                                        "on_trial_finish": "addID()"}
+                       			} 
+    
+   }
 ]
+

--- a/post_task_smoking_abstinence_self_report/config.json
+++ b/post_task_smoking_abstinence_self_report/config.json
@@ -1,49 +1,51 @@
 [
-  {
-    "name": "Post-Task Smoking Abstinence Self-Report",
-    "template": "jspsych",
-    "run": [
-      "static/js/jspsych/jspsych.js",
-      "static/js/jspsych/plugins/jspsych-call-function.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-text.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-instructions.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-attention-check.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-single-stim.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-categorize.js",
-      "static/js/jspsych/plugins/jspsych-survey-text.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-stop-signal.js",
-      "static/css/jspsych.css",
-      "static/css/default_style.css",
-      "style.css",
-      "experiment.js"
-    ],
-    "exp_id": "post_task_smoking_abstinence_self_report",
-    "contributors": [
-      "Jamie Li",
-      "Ian Eisenberg",
-      "Patrick Bissett",
-      "Zeynep Enkavi",
-      "Sadiv Parikh",
-      "Russell Poldrack"
-    ],
-    "time": 30,
-    "reference": "http://psycnet.apa.org/journals/xlm/37/2/392/",
-    "notes": "Condition refers to whether the trial is practice or high_freq/low_freq (the two test conditions) as well as whether it was a go or SS trial",
-    "publish": "True",
-    "experiment_variables": [
-      {
-        "name": "credit_var",
-        "type": "credit",
-        "datatype": "boolean",
-        "description": "True if avg_rt > 200"
-      }
-    ],
-    "deployment_variables": {
-      "jspsych_init": {
-        "fullscreen": true,
-        "display_element": "getDisplayElement",
-        "on_trial_finish": "addID()"
-      }
-    }
-  }
+    {
+        "name": "Post-Task Smoking Abstinence Self-Report",
+        "template":"jspsych",
+        "run": [
+
+                "static/js/jspsych/jspsych.js",
+                "static/js/jspsych/plugins/jspsych-call-function.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-text.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-instructions.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-attention-check.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-single-stim.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-categorize.js",
+                "static/js/jspsych/plugins/jspsych-survey-text.js", 
+                "static/js/jspsych/poldrack_plugins/jspsych-stop-signal.js",
+                "static/css/jspsych.css",
+                "static/css/default_style.css",
+                "style.css",
+                "experiment.js"
+                
+                
+               ],
+        "exp_id": "post_task_smoking_abstinence_self_report",
+        "cognitive_atlas_task_id": "tsk_4a57abb949e1a",
+        "contributors": [
+                         "Jamie Li",
+                         "Ian Eisenberg",
+                         "Patrick Bissett",
+                         "Zeynep Enkavi",
+                         "Sadiv Parikh",
+                         "Russell Poldrack"
+                        ], 
+        "time":30,
+        "reference": "http://psycnet.apa.org/journals/xlm/37/2/392/",
+        "notes": "Condition refers to whether the trial is practice or high_freq/low_freq (the two test conditions) as well as whether it was a go or SS trial",
+        "publish":"True",
+        "experiment_variables": [{
+                                 "name":"credit_var",
+                                 "type":"credit",
+                                 "datatype": "boolean",
+                                 "description":"True if avg_rt > 200"
+                                  }],
+        "deployment_variables":{"jspsych_init":
+                                        {"fullscreen": true,
+                                        "display_element": "getDisplayElement",
+                                        "on_trial_finish": "addID()"}
+                       			} 
+    
+   }
 ]
+

--- a/pre_task_eating_abstinence_self_report/config.json
+++ b/pre_task_eating_abstinence_self_report/config.json
@@ -1,49 +1,51 @@
 [
-  {
-    "name": "Pre-Task Eating Abstinence Self-Report",
-    "template": "jspsych",
-    "run": [
-      "static/js/jspsych/jspsych.js",
-      "static/js/jspsych/plugins/jspsych-call-function.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-text.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-instructions.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-attention-check.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-single-stim.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-categorize.js",
-      "static/js/jspsych/plugins/jspsych-survey-text.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-stop-signal.js",
-      "static/css/jspsych.css",
-      "static/css/default_style.css",
-      "style.css",
-      "experiment.js"
-    ],
-    "exp_id": "pre_task_eating_abstinence_self_report",
-    "contributors": [
-      "Jamie Li",
-      "Ian Eisenberg",
-      "Patrick Bissett",
-      "Zeynep Enkavi",
-      "Sadiv Parikh",
-      "Russell Poldrack"
-    ],
-    "time": 30,
-    "reference": "http://psycnet.apa.org/journals/xlm/37/2/392/",
-    "notes": "Condition refers to whether the trial is practice or high_freq/low_freq (the two test conditions) as well as whether it was a go or SS trial",
-    "publish": "True",
-    "experiment_variables": [
-      {
-        "name": "credit_var",
-        "type": "credit",
-        "datatype": "boolean",
-        "description": "True if avg_rt > 200"
-      }
-    ],
-    "deployment_variables": {
-      "jspsych_init": {
-        "fullscreen": true,
-        "display_element": "getDisplayElement",
-        "on_trial_finish": "addID()"
-      }
-    }
-  }
+    {
+        "name": "Pre-Task Eating Abstinence Self-Report",
+        "template":"jspsych",
+        "run": [
+
+                "static/js/jspsych/jspsych.js",
+                "static/js/jspsych/plugins/jspsych-call-function.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-text.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-instructions.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-attention-check.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-single-stim.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-categorize.js",
+                "static/js/jspsych/plugins/jspsych-survey-text.js", 
+                "static/js/jspsych/poldrack_plugins/jspsych-stop-signal.js",
+                "static/css/jspsych.css",
+                "static/css/default_style.css",
+                "style.css",
+                "experiment.js"
+                
+                
+               ],
+        "exp_id": "pre_task_eating_abstinence_self_report",
+        "cognitive_atlas_task_id": "tsk_4a57abb949e1a",
+        "contributors": [
+                         "Jamie Li",
+                         "Ian Eisenberg",
+                         "Patrick Bissett",
+                         "Zeynep Enkavi",
+                         "Sadiv Parikh",
+                         "Russell Poldrack"
+                        ], 
+        "time":30,
+        "reference": "http://psycnet.apa.org/journals/xlm/37/2/392/",
+        "notes": "Condition refers to whether the trial is practice or high_freq/low_freq (the two test conditions) as well as whether it was a go or SS trial",
+        "publish":"True",
+        "experiment_variables": [{
+                                 "name":"credit_var",
+                                 "type":"credit",
+                                 "datatype": "boolean",
+                                 "description":"True if avg_rt > 200"
+                                  }],
+        "deployment_variables":{"jspsych_init":
+                                        {"fullscreen": true,
+                                        "display_element": "getDisplayElement",
+                                        "on_trial_finish": "addID()"}
+                       			} 
+    
+   }
 ]
+

--- a/pre_task_smoking_abstinence_self_report/config.json
+++ b/pre_task_smoking_abstinence_self_report/config.json
@@ -1,49 +1,51 @@
 [
-  {
-    "name": "Pre-Task Smoking Abstinence Self-Report",
-    "template": "jspsych",
-    "run": [
-      "static/js/jspsych/jspsych.js",
-      "static/js/jspsych/plugins/jspsych-call-function.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-text.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-instructions.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-attention-check.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-single-stim.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-categorize.js",
-      "static/js/jspsych/plugins/jspsych-survey-text.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-stop-signal.js",
-      "static/css/jspsych.css",
-      "static/css/default_style.css",
-      "style.css",
-      "experiment.js"
-    ],
-    "exp_id": "pre_task_smoking_abstinence_self_report",
-    "contributors": [
-      "Jamie Li",
-      "Ian Eisenberg",
-      "Patrick Bissett",
-      "Zeynep Enkavi",
-      "Sadiv Parikh",
-      "Russell Poldrack"
-    ],
-    "time": 30,
-    "reference": "http://psycnet.apa.org/journals/xlm/37/2/392/",
-    "notes": "Condition refers to whether the trial is practice or high_freq/low_freq (the two test conditions) as well as whether it was a go or SS trial",
-    "publish": "True",
-    "experiment_variables": [
-      {
-        "name": "credit_var",
-        "type": "credit",
-        "datatype": "boolean",
-        "description": "True if avg_rt > 200"
-      }
-    ],
-    "deployment_variables": {
-      "jspsych_init": {
-        "fullscreen": true,
-        "display_element": "getDisplayElement",
-        "on_trial_finish": "addID()"
-      }
-    }
-  }
+    {
+        "name": "Pre-Task Smoking Abstinence Self-Report",
+        "template":"jspsych",
+        "run": [
+
+                "static/js/jspsych/jspsych.js",
+                "static/js/jspsych/plugins/jspsych-call-function.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-text.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-instructions.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-attention-check.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-single-stim.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-categorize.js",
+                "static/js/jspsych/plugins/jspsych-survey-text.js", 
+                "static/js/jspsych/poldrack_plugins/jspsych-stop-signal.js",
+                "static/css/jspsych.css",
+                "static/css/default_style.css",
+                "style.css",
+                "experiment.js"
+                
+                
+               ],
+        "exp_id": "pre_task_smoking_abstinence_self_report",
+        "cognitive_atlas_task_id": "tsk_4a57abb949e1a",
+        "contributors": [
+                         "Jamie Li",
+                         "Ian Eisenberg",
+                         "Patrick Bissett",
+                         "Zeynep Enkavi",
+                         "Sadiv Parikh",
+                         "Russell Poldrack"
+                        ], 
+        "time":30,
+        "reference": "http://psycnet.apa.org/journals/xlm/37/2/392/",
+        "notes": "Condition refers to whether the trial is practice or high_freq/low_freq (the two test conditions) as well as whether it was a go or SS trial",
+        "publish":"True",
+        "experiment_variables": [{
+                                 "name":"credit_var",
+                                 "type":"credit",
+                                 "datatype": "boolean",
+                                 "description":"True if avg_rt > 200"
+                                  }],
+        "deployment_variables":{"jspsych_init":
+                                        {"fullscreen": true,
+                                        "display_element": "getDisplayElement",
+                                        "on_trial_finish": "addID()"}
+                       			} 
+    
+   }
 ]
+

--- a/predictable_task_switching_single_task_network/config.json
+++ b/predictable_task_switching_single_task_network/config.json
@@ -1,48 +1,47 @@
 [
-  {
-    "name": "Predictable Task Switching Single Task Network",
-    "template": "jspsych",
-    "run": [
-      "static/js/math.min.js",
-      "static/js/jspsych/jspsych.js",
-      "static/js/jspsych/plugins/jspsych-text.js",
-      "static/js/jspsych/plugins/jspsych-call-function.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-text.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-instructions.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-single-stim.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-categorize.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-attention-check.js",
-      "static/js/jspsych/plugins/jspsych-survey-text.js",
-      "static/js/utils/poldrack_utils.js",
-      "experiment.js",
-      "static/css/jspsych.css",
-      "static/css/default_style.css",
-      "style.css"
-    ],
-    "exp_id": "predictable_task_switching_single_task_network",
-    "contributors": [
-      "Patrick Bissett",
-      "Jamie Li",
-      "McKenzie Hagen",
-      "Russell Poldrack"
-    ],
-    "time": 20,
-    "reference": "http://psycnet.apa.org/psycarticles/2013-29647-001",
-    "publish": "True",
-    "experiment_variables": [
-      {
-        "name": "credit_var",
-        "type": "credit",
-        "datatype": "boolean",
-        "description": "True if avg_rt > 200"
-      }
-    ],
-    "deployment_variables": {
-      "jspsych_init": {
-        "fullscreen": true,
-        "display_element": "getDisplayElement",
-        "on_trial_finish": "addID('predictable_task_switching_single_task_network')"
-      }
-    }
-  }
+    {
+        "name": "Predictable Task Switching Single Task Network",
+        "template":"jspsych",
+        "run": [
+                "static/js/math.min.js",
+                "static/js/jspsych/jspsych.js",
+                "static/js/jspsych/plugins/jspsych-text.js",
+                "static/js/jspsych/plugins/jspsych-call-function.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-text.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-instructions.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-single-stim.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-categorize.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-attention-check.js",
+                "static/js/jspsych/plugins/jspsych-survey-text.js",
+                "static/js/utils/poldrack_utils.js",
+                "experiment.js",
+                "static/css/jspsych.css",
+                "static/css/default_style.css",
+                "style.css"
+               ],
+        "exp_id": "predictable_task_switching_single_task_network",
+        "cognitive_atlas_task_id": "trm_4f241ee9c4e37",
+        "contributors": [
+                         "Patrick Bissett",
+                         "Jamie Li",
+                         "McKenzie Hagen",
+                         "Russell Poldrack"
+                        ], 
+        "time":20,
+        "reference": "http://psycnet.apa.org/psycarticles/2013-29647-001",
+        "publish":"True",
+        "experiment_variables": [{
+                                 "name":"credit_var",
+                                 "type":"credit",
+                                 "datatype": "boolean",
+                                 "description":"True if avg_rt > 200"
+                                  }],
+        "deployment_variables":{"jspsych_init":
+                                        {"fullscreen": true,
+                                        "display_element": "getDisplayElement",
+                                        "on_trial_finish": "addID('predictable_task_switching_single_task_network')"}
+                       }
+    
+   }
 ]
+

--- a/predictable_task_switching_with_cued_task_switching/config.json
+++ b/predictable_task_switching_with_cued_task_switching/config.json
@@ -1,48 +1,49 @@
 [
-  {
-    "name": "Predictable Task Switching with Cued Task Switching",
-    "template": "jspsych",
-    "run": [
-      "static/js/math.min.js",
-      "static/js/jspsych/jspsych.js",
-      "static/js/jspsych/plugins/jspsych-call-function.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-text.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-instructions.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-attention-check.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-single-stim.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-categorize.js",
-      "static/js/jspsych/plugins/jspsych-survey-text.js",
-      "experiment.js",
-      "static/css/jspsych.css",
-      "static/css/default_style.css",
-      "style.css",
-      "https://cdnjs.cloudflare.com/ajax/libs/mathjs/3.13.3/math.js"
-    ],
-    "exp_id": "predictable_task_switching_with_cued_task_switching",
-    "contributors": [
-      "Patrick Bissett",
-      "Jamie Li",
-      "McKenzie Hagen",
-      "Russell Poldrack"
-    ],
-    "time": 30,
-    "reference": "http://psycnet.apa.org/journals/xlm/37/2/392/",
-    "notes": "Condition refers to whether the trial is practice or high_freq/low_freq (the two test conditions) as well as whether it was a go or SS trial",
-    "publish": "True",
-    "experiment_variables": [
-      {
-        "name": "credit_var",
-        "type": "credit",
-        "datatype": "boolean",
-        "description": "True if avg_rt > 200"
-      }
-    ],
-    "deployment_variables": {
-      "jspsych_init": {
-        "fullscreen": true,
-        "display_element": "getDisplayElement",
-        "on_trial_finish": "addID('predictable_task_switching_with_cued_task_switching')"
-      }
-    }
-  }
+    {
+        "name": "Predictable Task Switching with Cued Task Switching",
+        "template":"jspsych",
+        "run": [
+				"static/js/math.min.js",
+                "static/js/jspsych/jspsych.js",
+                "static/js/jspsych/plugins/jspsych-call-function.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-text.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-instructions.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-attention-check.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-single-stim.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-categorize.js",
+                "static/js/jspsych/plugins/jspsych-survey-text.js", 
+                "experiment.js",
+                "static/css/jspsych.css",
+                "static/css/default_style.css",
+                "style.css",
+                "https://cdnjs.cloudflare.com/ajax/libs/mathjs/3.13.3/math.js"
+                
+                
+               ],
+        "exp_id": "predictable_task_switching_with_cued_task_switching",
+        "cognitive_atlas_task_id": "tsk_4a57abb949e1a",
+        "contributors": [
+        				 "Patrick Bissett",
+                         "Jamie Li",
+                         "McKenzie Hagen",
+                         "Russell Poldrack"
+                        ], 
+        "time":30,
+        "reference": "http://psycnet.apa.org/journals/xlm/37/2/392/",
+        "notes": "Condition refers to whether the trial is practice or high_freq/low_freq (the two test conditions) as well as whether it was a go or SS trial",
+        "publish":"True",
+        "experiment_variables": [{
+                                 "name":"credit_var",
+                                 "type":"credit",
+                                 "datatype": "boolean",
+                                 "description":"True if avg_rt > 200"
+                                  }],
+        "deployment_variables":{"jspsych_init":
+                                        {"fullscreen": true,
+                                        "display_element": "getDisplayElement",
+                                        "on_trial_finish": "addID('predictable_task_switching_with_cued_task_switching')"}
+                       			} 
+    
+   }
 ]
+

--- a/qewp5__dartmouth_baseline/config.json
+++ b/qewp5__dartmouth_baseline/config.json
@@ -1,49 +1,51 @@
 [
-  {
-    "name": "QEWP-5 Dartmouth Baseline",
-    "template": "jspsych",
-    "run": [
-      "static/js/jspsych/jspsych.js",
-      "static/js/jspsych/plugins/jspsych-call-function.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-text.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-instructions.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-attention-check.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-single-stim.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-categorize.js",
-      "static/js/jspsych/plugins/jspsych-survey-text.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-stop-signal.js",
-      "static/css/jspsych.css",
-      "static/css/default_style.css",
-      "style.css",
-      "experiment.js"
-    ],
-    "exp_id": "qewp5__dartmouth_baseline",
-    "contributors": [
-      "Jamie Li",
-      "Ian Eisenberg",
-      "Patrick Bissett",
-      "Zeynep Enkavi",
-      "Sadiv Parikh",
-      "Russell Poldrack"
-    ],
-    "time": 30,
-    "reference": "http://psycnet.apa.org/journals/xlm/37/2/392/",
-    "notes": "Condition refers to whether the trial is practice or high_freq/low_freq (the two test conditions) as well as whether it was a go or SS trial",
-    "publish": "True",
-    "experiment_variables": [
-      {
-        "name": "credit_var",
-        "type": "credit",
-        "datatype": "boolean",
-        "description": "True if avg_rt > 200"
-      }
-    ],
-    "deployment_variables": {
-      "jspsych_init": {
-        "fullscreen": true,
-        "display_element": "getDisplayElement",
-        "on_trial_finish": "addID()"
-      }
-    }
-  }
+    {
+        "name": "QEWP-5 Dartmouth Baseline",
+        "template":"jspsych",
+        "run": [
+
+                "static/js/jspsych/jspsych.js",
+                "static/js/jspsych/plugins/jspsych-call-function.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-text.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-instructions.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-attention-check.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-single-stim.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-categorize.js",
+                "static/js/jspsych/plugins/jspsych-survey-text.js", 
+                "static/js/jspsych/poldrack_plugins/jspsych-stop-signal.js",
+                "static/css/jspsych.css",
+                "static/css/default_style.css",
+                "style.css",
+                "experiment.js"
+                
+                
+               ],
+        "exp_id": "qewp5__dartmouth_baseline",
+        "cognitive_atlas_task_id": "tsk_4a57abb949e1a",
+        "contributors": [
+                         "Jamie Li",
+                         "Ian Eisenberg",
+                         "Patrick Bissett",
+                         "Zeynep Enkavi",
+                         "Sadiv Parikh",
+                         "Russell Poldrack"
+                        ], 
+        "time":30,
+        "reference": "http://psycnet.apa.org/journals/xlm/37/2/392/",
+        "notes": "Condition refers to whether the trial is practice or high_freq/low_freq (the two test conditions) as well as whether it was a go or SS trial",
+        "publish":"True",
+        "experiment_variables": [{
+                                 "name":"credit_var",
+                                 "type":"credit",
+                                 "datatype": "boolean",
+                                 "description":"True if avg_rt > 200"
+                                  }],
+        "deployment_variables":{"jspsych_init":
+                                        {"fullscreen": true,
+                                        "display_element": "getDisplayElement",
+                                        "on_trial_finish": "addID()"}
+                       			} 
+    
+   }
 ]
+

--- a/qewp5__dartmouth_followup/config.json
+++ b/qewp5__dartmouth_followup/config.json
@@ -1,49 +1,51 @@
 [
-  {
-    "name": "QEWP-5 Dartmouth Follow-up",
-    "template": "jspsych",
-    "run": [
-      "static/js/jspsych/jspsych.js",
-      "static/js/jspsych/plugins/jspsych-call-function.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-text.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-instructions.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-attention-check.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-single-stim.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-categorize.js",
-      "static/js/jspsych/plugins/jspsych-survey-text.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-stop-signal.js",
-      "static/css/jspsych.css",
-      "static/css/default_style.css",
-      "style.css",
-      "experiment.js"
-    ],
-    "exp_id": "qewp5__dartmouth_followup",
-    "contributors": [
-      "Jamie Li",
-      "Ian Eisenberg",
-      "Patrick Bissett",
-      "Zeynep Enkavi",
-      "Sadiv Parikh",
-      "Russell Poldrack"
-    ],
-    "time": 30,
-    "reference": "http://psycnet.apa.org/journals/xlm/37/2/392/",
-    "notes": "Condition refers to whether the trial is practice or high_freq/low_freq (the two test conditions) as well as whether it was a go or SS trial",
-    "publish": "True",
-    "experiment_variables": [
-      {
-        "name": "credit_var",
-        "type": "credit",
-        "datatype": "boolean",
-        "description": "True if avg_rt > 200"
-      }
-    ],
-    "deployment_variables": {
-      "jspsych_init": {
-        "fullscreen": true,
-        "display_element": "getDisplayElement",
-        "on_trial_finish": "addID()"
-      }
-    }
-  }
+    {
+        "name": "QEWP-5 Dartmouth Follow-up",
+        "template":"jspsych",
+        "run": [
+
+                "static/js/jspsych/jspsych.js",
+                "static/js/jspsych/plugins/jspsych-call-function.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-text.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-instructions.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-attention-check.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-single-stim.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-categorize.js",
+                "static/js/jspsych/plugins/jspsych-survey-text.js", 
+                "static/js/jspsych/poldrack_plugins/jspsych-stop-signal.js",
+                "static/css/jspsych.css",
+                "static/css/default_style.css",
+                "style.css",
+                "experiment.js"
+                
+                
+               ],
+        "exp_id": "qewp5__dartmouth_followup",
+        "cognitive_atlas_task_id": "tsk_4a57abb949e1a",
+        "contributors": [
+                         "Jamie Li",
+                         "Ian Eisenberg",
+                         "Patrick Bissett",
+                         "Zeynep Enkavi",
+                         "Sadiv Parikh",
+                         "Russell Poldrack"
+                        ], 
+        "time":30,
+        "reference": "http://psycnet.apa.org/journals/xlm/37/2/392/",
+        "notes": "Condition refers to whether the trial is practice or high_freq/low_freq (the two test conditions) as well as whether it was a go or SS trial",
+        "publish":"True",
+        "experiment_variables": [{
+                                 "name":"credit_var",
+                                 "type":"credit",
+                                 "datatype": "boolean",
+                                 "description":"True if avg_rt > 200"
+                                  }],
+        "deployment_variables":{"jspsych_init":
+                                        {"fullscreen": true,
+                                        "display_element": "getDisplayElement",
+                                        "on_trial_finish": "addID()"}
+                       			} 
+    
+   }
 ]
+

--- a/qewp5__stanford_baseline/config.json
+++ b/qewp5__stanford_baseline/config.json
@@ -1,49 +1,51 @@
 [
-  {
-    "name": "QEWP-5 Stanford Baseline",
-    "template": "jspsych",
-    "run": [
-      "static/js/jspsych/jspsych.js",
-      "static/js/jspsych/plugins/jspsych-call-function.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-text.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-instructions.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-attention-check.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-single-stim.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-categorize.js",
-      "static/js/jspsych/plugins/jspsych-survey-text.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-stop-signal.js",
-      "static/css/jspsych.css",
-      "static/css/default_style.css",
-      "style.css",
-      "experiment.js"
-    ],
-    "exp_id": "qewp5__stanford_baseline",
-    "contributors": [
-      "Jamie Li",
-      "Ian Eisenberg",
-      "Patrick Bissett",
-      "Zeynep Enkavi",
-      "Sadiv Parikh",
-      "Russell Poldrack"
-    ],
-    "time": 30,
-    "reference": "http://psycnet.apa.org/journals/xlm/37/2/392/",
-    "notes": "Condition refers to whether the trial is practice or high_freq/low_freq (the two test conditions) as well as whether it was a go or SS trial",
-    "publish": "True",
-    "experiment_variables": [
-      {
-        "name": "credit_var",
-        "type": "credit",
-        "datatype": "boolean",
-        "description": "True if avg_rt > 200"
-      }
-    ],
-    "deployment_variables": {
-      "jspsych_init": {
-        "fullscreen": true,
-        "display_element": "getDisplayElement",
-        "on_trial_finish": "addID()"
-      }
-    }
-  }
+    {
+        "name": "QEWP-5 Stanford Baseline",
+        "template":"jspsych",
+        "run": [
+
+                "static/js/jspsych/jspsych.js",
+                "static/js/jspsych/plugins/jspsych-call-function.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-text.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-instructions.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-attention-check.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-single-stim.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-categorize.js",
+                "static/js/jspsych/plugins/jspsych-survey-text.js", 
+                "static/js/jspsych/poldrack_plugins/jspsych-stop-signal.js",
+                "static/css/jspsych.css",
+                "static/css/default_style.css",
+                "style.css",
+                "experiment.js"
+                
+                
+               ],
+        "exp_id": "qewp5__stanford_baseline",
+        "cognitive_atlas_task_id": "tsk_4a57abb949e1a",
+        "contributors": [
+                         "Jamie Li",
+                         "Ian Eisenberg",
+                         "Patrick Bissett",
+                         "Zeynep Enkavi",
+                         "Sadiv Parikh",
+                         "Russell Poldrack"
+                        ], 
+        "time":30,
+        "reference": "http://psycnet.apa.org/journals/xlm/37/2/392/",
+        "notes": "Condition refers to whether the trial is practice or high_freq/low_freq (the two test conditions) as well as whether it was a go or SS trial",
+        "publish":"True",
+        "experiment_variables": [{
+                                 "name":"credit_var",
+                                 "type":"credit",
+                                 "datatype": "boolean",
+                                 "description":"True if avg_rt > 200"
+                                  }],
+        "deployment_variables":{"jspsych_init":
+                                        {"fullscreen": true,
+                                        "display_element": "getDisplayElement",
+                                        "on_trial_finish": "addID()"}
+                       			} 
+    
+   }
 ]
+

--- a/qewp5__stanford_followup/config.json
+++ b/qewp5__stanford_followup/config.json
@@ -1,49 +1,51 @@
 [
-  {
-    "name": "QEWP-5 Stanford Follow-up",
-    "template": "jspsych",
-    "run": [
-      "static/js/jspsych/jspsych.js",
-      "static/js/jspsych/plugins/jspsych-call-function.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-text.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-instructions.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-attention-check.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-single-stim.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-categorize.js",
-      "static/js/jspsych/plugins/jspsych-survey-text.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-stop-signal.js",
-      "static/css/jspsych.css",
-      "static/css/default_style.css",
-      "style.css",
-      "experiment.js"
-    ],
-    "exp_id": "qewp5__stanford_followup",
-    "contributors": [
-      "Jamie Li",
-      "Ian Eisenberg",
-      "Patrick Bissett",
-      "Zeynep Enkavi",
-      "Sadiv Parikh",
-      "Russell Poldrack"
-    ],
-    "time": 30,
-    "reference": "http://psycnet.apa.org/journals/xlm/37/2/392/",
-    "notes": "Condition refers to whether the trial is practice or high_freq/low_freq (the two test conditions) as well as whether it was a go or SS trial",
-    "publish": "True",
-    "experiment_variables": [
-      {
-        "name": "credit_var",
-        "type": "credit",
-        "datatype": "boolean",
-        "description": "True if avg_rt > 200"
-      }
-    ],
-    "deployment_variables": {
-      "jspsych_init": {
-        "fullscreen": true,
-        "display_element": "getDisplayElement",
-        "on_trial_finish": "addID()"
-      }
-    }
-  }
+    {
+        "name": "QEWP-5 Stanford Follow-up",
+        "template":"jspsych",
+        "run": [
+
+                "static/js/jspsych/jspsych.js",
+                "static/js/jspsych/plugins/jspsych-call-function.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-text.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-instructions.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-attention-check.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-single-stim.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-categorize.js",
+                "static/js/jspsych/plugins/jspsych-survey-text.js", 
+                "static/js/jspsych/poldrack_plugins/jspsych-stop-signal.js",
+                "static/css/jspsych.css",
+                "static/css/default_style.css",
+                "style.css",
+                "experiment.js"
+                
+                
+               ],
+        "exp_id": "qewp5__stanford_followup",
+        "cognitive_atlas_task_id": "tsk_4a57abb949e1a",
+        "contributors": [
+                         "Jamie Li",
+                         "Ian Eisenberg",
+                         "Patrick Bissett",
+                         "Zeynep Enkavi",
+                         "Sadiv Parikh",
+                         "Russell Poldrack"
+                        ], 
+        "time":30,
+        "reference": "http://psycnet.apa.org/journals/xlm/37/2/392/",
+        "notes": "Condition refers to whether the trial is practice or high_freq/low_freq (the two test conditions) as well as whether it was a go or SS trial",
+        "publish":"True",
+        "experiment_variables": [{
+                                 "name":"credit_var",
+                                 "type":"credit",
+                                 "datatype": "boolean",
+                                 "description":"True if avg_rt > 200"
+                                  }],
+        "deployment_variables":{"jspsych_init":
+                                        {"fullscreen": true,
+                                        "display_element": "getDisplayElement",
+                                        "on_trial_finish": "addID()"}
+                       			} 
+    
+   }
 ]
+

--- a/rep_drift/config.json
+++ b/rep_drift/config.json
@@ -1,47 +1,49 @@
 [
-  {
-    "name": "Rep Drift",
-    "template": "jspsych",
-    "run": [
-      "static/js/jspsych/jspsych.js",
-      "static/js/jspsych/plugins/jspsych-call-function.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-text.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-instructions.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-attention-check.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-single-stim.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-categorize.js",
-      "static/js/jspsych/plugins/jspsych-survey-text.js",
-      "experiment.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-stop-signal.js",
-      "static/css/jspsych.css",
-      "static/css/default_style.css",
-      "style.css",
-      "https://cdnjs.cloudflare.com/ajax/libs/mathjs/3.13.3/math.js"
-    ],
-    "exp_id": "rep_drift",
-    "contributors": [
-      "Jamie Li",
-      "Ian Eisenberg",
-      "Russell Poldrack"
-    ],
-    "time": 30,
-    "reference": "http://psycnet.apa.org/journals/xlm/37/2/392/",
-    "notes": "Condition refers to whether the trial is practice or high_freq/low_freq (the two test conditions) as well as whether it was a go or SS trial",
-    "publish": "True",
-    "experiment_variables": [
-      {
-        "name": "credit_var",
-        "type": "credit",
-        "datatype": "boolean",
-        "description": "True if avg_rt > 200"
-      }
-    ],
-    "deployment_variables": {
-      "jspsych_init": {
-        "fullscreen": true,
-        "display_element": "getDisplayElement",
-        "on_trial_finish": "addID()"
-      }
-    }
-  }
+    {
+        "name": "Rep Drift",
+        "template":"jspsych",
+        "run": [
+
+                "static/js/jspsych/jspsych.js",
+                "static/js/jspsych/plugins/jspsych-call-function.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-text.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-instructions.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-attention-check.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-single-stim.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-categorize.js",
+                "static/js/jspsych/plugins/jspsych-survey-text.js", 
+                "experiment.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-stop-signal.js",
+                "static/css/jspsych.css",
+                "static/css/default_style.css",
+                "style.css",
+                "https://cdnjs.cloudflare.com/ajax/libs/mathjs/3.13.3/math.js"
+                
+                
+               ],
+        "exp_id": "rep_drift",
+        "cognitive_atlas_task_id": "tsk_4a57abb949e1a",
+        "contributors": [
+                         "Jamie Li",
+                         "Ian Eisenberg",
+                         "Russell Poldrack"
+                        ], 
+        "time":30,
+        "reference": "http://psycnet.apa.org/journals/xlm/37/2/392/",
+        "notes": "Condition refers to whether the trial is practice or high_freq/low_freq (the two test conditions) as well as whether it was a go or SS trial",
+        "publish":"True",
+        "experiment_variables": [{
+                                 "name":"credit_var",
+                                 "type":"credit",
+                                 "datatype": "boolean",
+                                 "description":"True if avg_rt > 200"
+                                  }],
+        "deployment_variables":{"jspsych_init":
+                                        {"fullscreen": true,
+                                        "display_element": "getDisplayElement",
+                                        "on_trial_finish": "addID()"}
+                       			} 
+    
+   }
 ]
+

--- a/rest__fmri/config.json
+++ b/rest__fmri/config.json
@@ -1,52 +1,49 @@
 [
-  {
-    "name": "UH2 Video",
-    "template": "jspsych",
-    "run": [
-      "static/js/math.min.js",
-      "static/js/jspsych/jspsych.js",
-      "static/js/jspsych/plugins/jspsych-text.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-text.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-instructions.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-attention-check.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-single-stim.js",
-      "static/js/jspsych/plugins/jspsych-single-stim.js",
-      "static/js/jspsych/plugins/jspsych-call-function.js",
-      "static/js/jspsych/plugins/jspsych-survey-text.js",
-      "static/js/utils/poldrack_utils.js",
-      "experiment.js",
-      "static/css/jspsych.css",
-      "static/css/default_style.css",
-      "style.css"
-    ],
-    "exp_id": "rest__fmri",
-    "contributors": [
-      "Jamie Li",
-      "Sadev Parikh",
-      "Ian Eisenberg",
-      "Zeynep Enkavi",
-      "Patrick Bissett",
-      "Vanessa Sochat",
-      "Russell Poldrack"
-    ],
-    "time": 8,
-    "reference": "http://www.sciencedirect.com/science/article/pii/0001691869900651",
-    "publish": "True",
-    "experiment_variables": [
-      {
-        "name": "credit_var",
-        "type": "credit",
-        "datatype": "boolean",
-        "description": "True if avg_rt > 200"
-      }
-    ],
-    "deployment_variables": {
-      "jspsych_init": {
-        "fullscreen": true,
-        "display_element": "getDisplayElement",
-        "on_trial_finish": "addID('rest__fmri')",
-        "on_trial_start": ""
-      }
-    }
-  }
+    {
+        "name": "UH2 Video",
+        "template":"jspsych",
+        "run": [
+                "static/js/math.min.js",
+                "static/js/jspsych/jspsych.js",
+                "static/js/jspsych/plugins/jspsych-text.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-text.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-instructions.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-attention-check.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-single-stim.js",
+                "static/js/jspsych/plugins/jspsych-single-stim.js",
+                "static/js/jspsych/plugins/jspsych-call-function.js",
+                "static/js/jspsych/plugins/jspsych-survey-text.js",
+                "static/js/utils/poldrack_utils.js",
+                "experiment.js",
+                "static/css/jspsych.css",
+                "static/css/default_style.css",
+                "style.css"
+               ],
+        "exp_id": "rest__fmri",
+        "cognitive_atlas_task_id": "tsk_4a57abb949dc8",
+        "contributors": [
+        				 "Jamie Li",
+        				 "Sadev Parikh",
+                         "Ian Eisenberg",
+                         "Zeynep Enkavi",
+                         "Patrick Bissett",
+                         "Vanessa Sochat",
+                         "Russell Poldrack"
+                        ], 
+        "time":8,
+        "reference": "http://www.sciencedirect.com/science/article/pii/0001691869900651",
+        "publish":"True",
+        "experiment_variables": [{
+                                 "name":"credit_var",
+                                 "type":"credit",
+                                 "datatype": "boolean",
+                                 "description":"True if avg_rt > 200"
+                                  }],
+        "deployment_variables":{"jspsych_init":
+                                        {"fullscreen": true,
+                                        "display_element": "getDisplayElement",
+                                        "on_trial_finish": "addID('rest__fmri')",
+                                        "on_trial_start": ""}
+                       }
+   }
 ]

--- a/screening_survey/config.json
+++ b/screening_survey/config.json
@@ -1,49 +1,50 @@
 [
-  {
-    "name": "Screening survey",
-    "template": "jspsych",
-    "run": [
-      "static/js/jspsych/jspsych.js",
-      "static/js/jspsych/plugins/jspsych-call-function.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-text.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-instructions.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-attention-check.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-single-stim.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-categorize.js",
-      "static/js/jspsych/plugins/jspsych-survey-text.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-stop-signal.js",
-      "static/css/jspsych.css",
-      "static/css/default_style.css",
-      "style.css",
-      "experiment.js"
-    ],
-    "exp_id": "screening_survey",
-    "contributors": [
-      "Matilde Vaghi",
-      "Ian Eisenberg",
-      "Patrick Bissett",
-      "Zeynep Enkavi",
-      "Sadiv Parikh",
-      "Russell Poldrack"
-    ],
-    "time": 30,
-    "reference": "",
-    "notes": "",
-    "publish": "True",
-    "experiment_variables": [
-      {
-        "name": "credit_var",
-        "type": "credit",
-        "datatype": "boolean",
-        "description": "True if avg_rt > 200"
-      }
-    ],
-    "deployment_variables": {
-      "jspsych_init": {
-        "fullscreen": true,
-        "display_element": "getDisplayElement",
-        "on_trial_finish": "addID()"
-      }
-    }
-  }
+    {
+        "name": "Screening survey",
+        "template":"jspsych",
+        "run": [
+
+                "static/js/jspsych/jspsych.js",
+                "static/js/jspsych/plugins/jspsych-call-function.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-text.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-instructions.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-attention-check.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-single-stim.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-categorize.js",
+                "static/js/jspsych/plugins/jspsych-survey-text.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-stop-signal.js",
+                "static/css/jspsych.css",
+                "static/css/default_style.css",
+                "style.css",
+                "experiment.js"
+
+
+               ],
+        "exp_id": "screening_survey",
+        "cognitive_atlas_task_id": "tsk_4a57abb949e1a",
+        "contributors": [
+                         "Matilde Vaghi",
+                         "Ian Eisenberg",
+                         "Patrick Bissett",
+                         "Zeynep Enkavi",
+                         "Sadiv Parikh",
+                         "Russell Poldrack"
+                        ],
+        "time":30,
+        "reference": "",
+        "notes": "",
+        "publish":"True",
+        "experiment_variables": [{
+                                 "name":"credit_var",
+                                 "type":"credit",
+                                 "datatype": "boolean",
+                                 "description":"True if avg_rt > 200"
+                                  }],
+        "deployment_variables":{"jspsych_init":
+                                        {"fullscreen": true,
+                                        "display_element": "getDisplayElement",
+                                        "on_trial_finish": "addID()"}
+                       			}
+
+   }
 ]

--- a/shape_matching/config.json
+++ b/shape_matching/config.json
@@ -1,43 +1,42 @@
 [
-  {
-    "name": "Shape Matching",
-    "template": "jspsych",
-    "run": [
-      "static/js/math.min.js",
-      "static/js/jspsych/jspsych.js",
-      "static/js/jspsych/plugins/jspsych-text.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-text.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-instructions.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-single-stim.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-categorize.js",
-      "static/js/jspsych/plugins/jspsych-survey-text.js",
-      "static/js/utils/poldrack_utils.js",
-      "experiment.js",
-      "static/css/jspsych.css",
-      "static/css/default_style.css",
-      "style.css"
-    ],
-    "exp_id": "shape_matching",
-    "contributors": [
-      "Ian Eisenberg"
-    ],
-    "time": 20,
-    "reference": "http://psycnet.apa.org/psycarticles/2013-29647-001",
-    "publish": "True",
-    "experiment_variables": [
-      {
-        "name": "credit_var",
-        "type": "credit",
-        "datatype": "boolean",
-        "description": "True if avg_rt > 200"
-      }
-    ],
-    "deployment_variables": {
-      "jspsych_init": {
-        "fullscreen": true,
-        "display_element": "getDisplayElement",
-        "on_trial_finish": "addID('shape_matching')"
-      }
-    }
-  }
+    {
+        "name": "Shape Matching",
+        "template":"jspsych",
+        "run": [
+                "static/js/math.min.js",
+                "static/js/jspsych/jspsych.js",
+                "static/js/jspsych/plugins/jspsych-text.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-text.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-instructions.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-single-stim.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-categorize.js",
+                "static/js/jspsych/plugins/jspsych-survey-text.js",
+                "static/js/utils/poldrack_utils.js",
+                "experiment.js",
+                "static/css/jspsych.css",
+                "static/css/default_style.css",
+                "style.css"
+               ],
+        "exp_id": "shape_matching",
+        "cognitive_atlas_task_id": "trm_4f241ee9c4e37",
+        "contributors": [
+                         "Ian Eisenberg"
+                        ], 
+        "time":20,
+        "reference": "http://psycnet.apa.org/psycarticles/2013-29647-001",
+        "publish":"True",
+        "experiment_variables": [{
+                                 "name":"credit_var",
+                                 "type":"credit",
+                                 "datatype": "boolean",
+                                 "description":"True if avg_rt > 200"
+                                  }],
+        "deployment_variables":{"jspsych_init":
+                                        {"fullscreen": true,
+                                        "display_element": "getDisplayElement",
+                                        "on_trial_finish": "addID('shape_matching')"}
+                       }
+    
+   }
 ]
+

--- a/shape_matching_single_task_network/config.json
+++ b/shape_matching_single_task_network/config.json
@@ -1,48 +1,47 @@
 [
-  {
-    "name": "Shape Matching Single Task Network",
-    "template": "jspsych",
-    "run": [
-      "static/js/math.min.js",
-      "static/js/jspsych/jspsych.js",
-      "static/js/jspsych/plugins/jspsych-text.js",
-      "static/js/jspsych/plugins/jspsych-call-function.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-text.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-instructions.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-single-stim.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-categorize.js",
-      "static/js/jspsych/plugins/jspsych-survey-text.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-attention-check.js",
-      "static/js/utils/poldrack_utils.js",
-      "experiment.js",
-      "static/css/jspsych.css",
-      "static/css/default_style.css",
-      "style.css"
-    ],
-    "exp_id": "shape_matching_single_task_network",
-    "contributors": [
-      "Patrick Bissett",
-      "Jamie Li",
-      "McKenzie Hagen",
-      "Russell Poldrack"
-    ],
-    "time": 20,
-    "reference": "http://psycnet.apa.org/psycarticles/2013-29647-001",
-    "publish": "True",
-    "experiment_variables": [
-      {
-        "name": "credit_var",
-        "type": "credit",
-        "datatype": "boolean",
-        "description": "True if avg_rt > 200"
-      }
-    ],
-    "deployment_variables": {
-      "jspsych_init": {
-        "fullscreen": true,
-        "display_element": "getDisplayElement",
-        "on_trial_finish": "addID('shape_matching_single_task_network')"
-      }
-    }
-  }
+    {
+        "name": "Shape Matching Single Task Network",
+        "template":"jspsych",
+        "run": [
+                "static/js/math.min.js",
+                "static/js/jspsych/jspsych.js",
+                "static/js/jspsych/plugins/jspsych-text.js",
+                "static/js/jspsych/plugins/jspsych-call-function.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-text.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-instructions.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-single-stim.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-categorize.js",
+                "static/js/jspsych/plugins/jspsych-survey-text.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-attention-check.js",
+                "static/js/utils/poldrack_utils.js",
+                "experiment.js",
+                "static/css/jspsych.css",
+                "static/css/default_style.css",
+                "style.css"
+               ],
+        "exp_id": "shape_matching_single_task_network",
+        "cognitive_atlas_task_id": "trm_4f241ee9c4e37",
+        "contributors": [
+                         "Patrick Bissett",
+                         "Jamie Li",
+                         "McKenzie Hagen",
+                         "Russell Poldrack"
+                        ], 
+        "time":20,
+        "reference": "http://psycnet.apa.org/psycarticles/2013-29647-001",
+        "publish":"True",
+        "experiment_variables": [{
+                                 "name":"credit_var",
+                                 "type":"credit",
+                                 "datatype": "boolean",
+                                 "description":"True if avg_rt > 200"
+                                  }],
+        "deployment_variables":{"jspsych_init":
+                                        {"fullscreen": true,
+                                        "display_element": "getDisplayElement",
+                                        "on_trial_finish": "addID('shape_matching_single_task_network')"}
+                       }
+    
+   }
 ]
+

--- a/shape_matching_single_task_network__fmri/config.json
+++ b/shape_matching_single_task_network__fmri/config.json
@@ -1,50 +1,49 @@
 [
-  {
-    "name": "Shape Matching Single Task Network fMRI",
-    "template": "jspsych",
-    "run": [
-      "static/js/math.min.js",
-      "static/js/jspsych/jspsych.js",
-      "static/js/jspsych/plugins/jspsych-text.js",
-      "static/js/jspsych/plugins/jspsych-call-function.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-text.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-instructions.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-single-stim.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-categorize.js",
-      "static/js/jspsych/plugins/jspsych-survey-text.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-attention-check.js",
-      "static/js/utils/poldrack_utils.js",
-      "static/js/utils/poldrack_fmri_utils.js",
-      "experiment.js",
-      "static/css/jspsych.css",
-      "static/css/default_style.css",
-      "style.css"
-    ],
-    "exp_id": "shape_matching_single_task_network__fmri",
-    "contributors": [
-      "Patrick Bissett",
-      "Jamie Li",
-      "McKenzie Hagen",
-      "Henry Jones",
-      "Russell Poldrack"
-    ],
-    "time": 20,
-    "reference": "http://psycnet.apa.org/psycarticles/2013-29647-001",
-    "publish": "True",
-    "experiment_variables": [
-      {
-        "name": "credit_var",
-        "type": "credit",
-        "datatype": "boolean",
-        "description": "True if avg_rt > 200"
-      }
-    ],
-    "deployment_variables": {
-      "jspsych_init": {
-        "fullscreen": true,
-        "display_element": "getDisplayElement",
-        "on_trial_finish": "addID('shape_matching_single_task_network__fmri')"
-      }
-    }
-  }
+    {
+        "name": "Shape Matching Single Task Network fMRI",
+        "template":"jspsych",
+        "run": [
+                "static/js/math.min.js",
+                "static/js/jspsych/jspsych.js",
+                "static/js/jspsych/plugins/jspsych-text.js",
+                "static/js/jspsych/plugins/jspsych-call-function.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-text.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-instructions.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-single-stim.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-categorize.js",
+                "static/js/jspsych/plugins/jspsych-survey-text.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-attention-check.js",
+                "static/js/utils/poldrack_utils.js",
+                "static/js/utils/poldrack_fmri_utils.js", 
+                "experiment.js",
+                "static/css/jspsych.css",
+                "static/css/default_style.css",
+                "style.css"
+               ],
+        "exp_id": "shape_matching_single_task_network__fmri",
+        "cognitive_atlas_task_id": "trm_4f241ee9c4e37",
+        "contributors": [
+                         "Patrick Bissett",
+                         "Jamie Li",
+                         "McKenzie Hagen",
+                         "Henry Jones",
+                         "Russell Poldrack"
+                        ], 
+        "time":20,
+        "reference": "http://psycnet.apa.org/psycarticles/2013-29647-001",
+        "publish":"True",
+        "experiment_variables": [{
+                                 "name":"credit_var",
+                                 "type":"credit",
+                                 "datatype": "boolean",
+                                 "description":"True if avg_rt > 200"
+                                  }],
+        "deployment_variables":{"jspsych_init":
+                                        {"fullscreen": true,
+                                        "display_element": "getDisplayElement",
+                                        "on_trial_finish": "addID('shape_matching_single_task_network__fmri')"}
+                       }
+    
+   }
 ]
+

--- a/shape_matching_single_task_network__practice/config.json
+++ b/shape_matching_single_task_network__practice/config.json
@@ -1,50 +1,49 @@
 [
-  {
-    "name": "Shape Matching Single Task Network fMRI Practice",
-    "template": "jspsych",
-    "run": [
-      "static/js/math.min.js",
-      "static/js/jspsych/jspsych.js",
-      "static/js/jspsych/plugins/jspsych-text.js",
-      "static/js/jspsych/plugins/jspsych-call-function.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-text.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-instructions.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-single-stim.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-categorize.js",
-      "static/js/jspsych/plugins/jspsych-survey-text.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-attention-check.js",
-      "static/js/utils/poldrack_utils.js",
-      "static/js/utils/poldrack_fmri_utils.js",
-      "experiment.js",
-      "static/css/jspsych.css",
-      "static/css/default_style.css",
-      "style.css"
-    ],
-    "exp_id": "shape_matching_single_task_network__practice",
-    "contributors": [
-      "Patrick Bissett",
-      "Jamie Li",
-      "McKenzie Hagen",
-      "Henry Jones",
-      "Russell Poldrack"
-    ],
-    "time": 20,
-    "reference": "http://psycnet.apa.org/psycarticles/2013-29647-001",
-    "publish": "True",
-    "experiment_variables": [
-      {
-        "name": "credit_var",
-        "type": "credit",
-        "datatype": "boolean",
-        "description": "True if avg_rt > 200"
-      }
-    ],
-    "deployment_variables": {
-      "jspsych_init": {
-        "fullscreen": true,
-        "display_element": "getDisplayElement",
-        "on_trial_finish": "addID('shape_matching_single_task_network__practice')"
-      }
-    }
-  }
+    {
+        "name": "Shape Matching Single Task Network fMRI Practice",
+        "template":"jspsych",
+        "run": [
+                "static/js/math.min.js",
+                "static/js/jspsych/jspsych.js",
+                "static/js/jspsych/plugins/jspsych-text.js",
+                "static/js/jspsych/plugins/jspsych-call-function.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-text.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-instructions.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-single-stim.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-categorize.js",
+                "static/js/jspsych/plugins/jspsych-survey-text.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-attention-check.js",
+                "static/js/utils/poldrack_utils.js",
+                "static/js/utils/poldrack_fmri_utils.js", 
+                "experiment.js",
+                "static/css/jspsych.css",
+                "static/css/default_style.css",
+                "style.css"
+               ],
+        "exp_id": "shape_matching_single_task_network__practice",
+        "cognitive_atlas_task_id": "trm_4f241ee9c4e37",
+        "contributors": [
+                         "Patrick Bissett",
+                         "Jamie Li",
+                         "McKenzie Hagen",
+                         "Henry Jones",
+                         "Russell Poldrack"
+                        ], 
+        "time":20,
+        "reference": "http://psycnet.apa.org/psycarticles/2013-29647-001",
+        "publish":"True",
+        "experiment_variables": [{
+                                 "name":"credit_var",
+                                 "type":"credit",
+                                 "datatype": "boolean",
+                                 "description":"True if avg_rt > 200"
+                                  }],
+        "deployment_variables":{"jspsych_init":
+                                        {"fullscreen": true,
+                                        "display_element": "getDisplayElement",
+                                        "on_trial_finish": "addID('shape_matching_single_task_network__practice')"}
+                       }
+    
+   }
 ]
+

--- a/shape_matching_with_cued_task_switching/config.json
+++ b/shape_matching_with_cued_task_switching/config.json
@@ -1,49 +1,47 @@
 [
-  {
-    "name": "Shape Matching with Cued Task Switching",
-    "template": "jspsych",
-    "run": [
-      "static/js/math.min.js",
-      "static/js/jspsych/jspsych.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-text.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-instructions.js",
-      "static/js/jspsych/plugins/jspsych-call-function.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-attention-check.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-single-stim.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-categorize.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-stop-signal.js",
-      "static/js/jspsych/plugins/jspsych-call-function.js",
-      "static/js/jspsych/plugins/jspsych-survey-text.js",
-      "static/js/utils/poldrack_utils.js",
-      "experiment.js",
-      "static/css/jspsych.css",
-      "static/css/default_style.css",
-      "style.css"
-    ],
-    "exp_id": "shape_matching_with_cued_task_switching",
-    "contributors": [
-      "Patrick Bissett",
-      "Jamie Li",
-      "McKenzie Hagen",
-      "Russell Poldrack"
-    ],
-    "time": 24,
-    "reference": "http://www.ncbi.nlm.nih.gov/pubmed/21299334",
-    "publish": "True",
-    "experiment_variables": [
-      {
-        "name": "credit_var",
-        "type": "credit",
-        "datatype": "boolean",
-        "description": "True if avg_rt > 200"
-      }
-    ],
-    "deployment_variables": {
-      "jspsych_init": {
-        "fullscreen": true,
-        "display_element": "getDisplayElement",
-        "on_trial_finish": "addID('shape_matching_with_cued_task_switching')"
-      }
-    }
-  }
+    {
+        "name": "Shape Matching with Cued Task Switching",
+        "template":"jspsych",
+        "run": [
+                 "static/js/math.min.js",
+                 "static/js/jspsych/jspsych.js",
+                 "static/js/jspsych/poldrack_plugins/jspsych-poldrack-text.js",
+                 "static/js/jspsych/poldrack_plugins/jspsych-poldrack-instructions.js",
+                 "static/js/jspsych/plugins/jspsych-call-function.js",
+                 "static/js/jspsych/poldrack_plugins/jspsych-attention-check.js",
+                 "static/js/jspsych/poldrack_plugins/jspsych-poldrack-single-stim.js",
+                 "static/js/jspsych/poldrack_plugins/jspsych-poldrack-categorize.js",
+                 "static/js/jspsych/poldrack_plugins/jspsych-stop-signal.js",
+                 "static/js/jspsych/plugins/jspsych-call-function.js",
+                 "static/js/jspsych/plugins/jspsych-survey-text.js",
+                 "static/js/utils/poldrack_utils.js",
+                 "experiment.js",
+                 "static/css/jspsych.css",
+                 "static/css/default_style.css",
+                 "style.css"
+               ],
+        "exp_id": "shape_matching_with_cued_task_switching",
+        "cognitive_atlas_task_id": "trm_566745bbf272a",
+        "contributors": [
+                         "Patrick Bissett",
+                         "Jamie Li",
+                         "McKenzie Hagen",
+                         "Russell Poldrack"
+                        ], 
+        "time":24,
+        "reference": "http://www.ncbi.nlm.nih.gov/pubmed/21299334",
+        "publish":"True",
+        "experiment_variables": [{
+                                 "name":"credit_var",
+                                 "type":"credit",
+                                 "datatype": "boolean",
+                                 "description":"True if avg_rt > 200"
+                                  }],
+        "deployment_variables":{"jspsych_init":
+                                        {"fullscreen": true,
+                                        "display_element": "getDisplayElement",
+                                        "on_trial_finish": "addID('shape_matching_with_cued_task_switching')"}
+                       }
+    
+   }
 ]

--- a/shape_matching_with_predictable_task_switching/config.json
+++ b/shape_matching_with_predictable_task_switching/config.json
@@ -1,48 +1,47 @@
 [
-  {
-    "name": "Shape Matching with Predictable Task Switching",
-    "template": "jspsych",
-    "run": [
-      "static/js/math.min.js",
-      "static/js/jspsych/jspsych.js",
-      "static/js/jspsych/plugins/jspsych-text.js",
-      "static/js/jspsych/plugins/jspsych-call-function.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-text.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-instructions.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-single-stim.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-categorize.js",
-      "static/js/jspsych/plugins/jspsych-survey-text.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-attention-check.js",
-      "static/js/utils/poldrack_utils.js",
-      "experiment.js",
-      "static/css/jspsych.css",
-      "static/css/default_style.css",
-      "style.css"
-    ],
-    "exp_id": "shape_matching_with_predictable_task_switching",
-    "contributors": [
-      "Patrick Bissett",
-      "Jamie Li",
-      "McKenzie Hagen",
-      "Russell Poldrack"
-    ],
-    "time": 20,
-    "reference": "http://psycnet.apa.org/psycarticles/2013-29647-001",
-    "publish": "True",
-    "experiment_variables": [
-      {
-        "name": "credit_var",
-        "type": "credit",
-        "datatype": "boolean",
-        "description": "True if avg_rt > 200"
-      }
-    ],
-    "deployment_variables": {
-      "jspsych_init": {
-        "fullscreen": true,
-        "display_element": "getDisplayElement",
-        "on_trial_finish": "addID('shape_matching_with_predictable_task_switching')"
-      }
-    }
-  }
+    {
+        "name": "Shape Matching with Predictable Task Switching",
+        "template":"jspsych",
+        "run": [
+                "static/js/math.min.js",
+                "static/js/jspsych/jspsych.js",
+                "static/js/jspsych/plugins/jspsych-text.js",
+                "static/js/jspsych/plugins/jspsych-call-function.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-text.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-instructions.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-single-stim.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-categorize.js",
+                "static/js/jspsych/plugins/jspsych-survey-text.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-attention-check.js",
+                "static/js/utils/poldrack_utils.js",
+                "experiment.js",
+                "static/css/jspsych.css",
+                "static/css/default_style.css",
+                "style.css"
+               ],
+        "exp_id": "shape_matching_with_predictable_task_switching",
+        "cognitive_atlas_task_id": "trm_4f241ee9c4e37",
+        "contributors": [
+                         "Patrick Bissett",
+                         "Jamie Li",
+                         "McKenzie Hagen",
+                         "Russell Poldrack"
+                        ], 
+        "time":20,
+        "reference": "http://psycnet.apa.org/psycarticles/2013-29647-001",
+        "publish":"True",
+        "experiment_variables": [{
+                                 "name":"credit_var",
+                                 "type":"credit",
+                                 "datatype": "boolean",
+                                 "description":"True if avg_rt > 200"
+                                  }],
+        "deployment_variables":{"jspsych_init":
+                                        {"fullscreen": true,
+                                        "display_element": "getDisplayElement",
+                                        "on_trial_finish": "addID('shape_matching_with_predictable_task_switching')"}
+                       }
+    
+   }
 ]
+

--- a/smoking_followup_survey__dartmouth/config.json
+++ b/smoking_followup_survey__dartmouth/config.json
@@ -1,49 +1,51 @@
 [
-  {
-    "name": "Smoking Follow-up Survey (Dartmouth)",
-    "template": "jspsych",
-    "run": [
-      "static/js/jspsych/jspsych.js",
-      "static/js/jspsych/plugins/jspsych-call-function.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-text.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-instructions.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-attention-check.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-single-stim.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-categorize.js",
-      "static/js/jspsych/plugins/jspsych-survey-text.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-stop-signal.js",
-      "static/css/jspsych.css",
-      "static/css/default_style.css",
-      "style.css",
-      "experiment.js"
-    ],
-    "exp_id": "smoking_followup_survey__dartmouth",
-    "contributors": [
-      "Jamie Li",
-      "Ian Eisenberg",
-      "Patrick Bissett",
-      "Zeynep Enkavi",
-      "Sadiv Parikh",
-      "Russell Poldrack"
-    ],
-    "time": 30,
-    "reference": "http://psycnet.apa.org/journals/xlm/37/2/392/",
-    "notes": "Condition refers to whether the trial is practice or high_freq/low_freq (the two test conditions) as well as whether it was a go or SS trial",
-    "publish": "True",
-    "experiment_variables": [
-      {
-        "name": "credit_var",
-        "type": "credit",
-        "datatype": "boolean",
-        "description": "True if avg_rt > 200"
-      }
-    ],
-    "deployment_variables": {
-      "jspsych_init": {
-        "fullscreen": true,
-        "display_element": "getDisplayElement",
-        "on_trial_finish": "addID()"
-      }
-    }
-  }
+    {
+        "name": "Smoking Follow-up Survey (Dartmouth)",
+        "template":"jspsych",
+        "run": [
+
+                "static/js/jspsych/jspsych.js",
+                "static/js/jspsych/plugins/jspsych-call-function.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-text.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-instructions.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-attention-check.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-single-stim.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-categorize.js",
+                "static/js/jspsych/plugins/jspsych-survey-text.js", 
+                "static/js/jspsych/poldrack_plugins/jspsych-stop-signal.js",
+                "static/css/jspsych.css",
+                "static/css/default_style.css",
+                "style.css",
+                "experiment.js"
+                
+                
+               ],
+        "exp_id": "smoking_followup_survey__dartmouth",
+        "cognitive_atlas_task_id": "tsk_4a57abb949e1a",
+        "contributors": [
+                         "Jamie Li",
+                         "Ian Eisenberg",
+                         "Patrick Bissett",
+                         "Zeynep Enkavi",
+                         "Sadiv Parikh",
+                         "Russell Poldrack"
+                        ], 
+        "time":30,
+        "reference": "http://psycnet.apa.org/journals/xlm/37/2/392/",
+        "notes": "Condition refers to whether the trial is practice or high_freq/low_freq (the two test conditions) as well as whether it was a go or SS trial",
+        "publish":"True",
+        "experiment_variables": [{
+                                 "name":"credit_var",
+                                 "type":"credit",
+                                 "datatype": "boolean",
+                                 "description":"True if avg_rt > 200"
+                                  }],
+        "deployment_variables":{"jspsych_init":
+                                        {"fullscreen": true,
+                                        "display_element": "getDisplayElement",
+                                        "on_trial_finish": "addID()"}
+                       			} 
+    
+   }
 ]
+

--- a/smoking_followup_survey__stanford/config.json
+++ b/smoking_followup_survey__stanford/config.json
@@ -1,49 +1,51 @@
 [
-  {
-    "name": "Smoking Follow-up Survey (Stanford)",
-    "template": "jspsych",
-    "run": [
-      "static/js/jspsych/jspsych.js",
-      "static/js/jspsych/plugins/jspsych-call-function.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-text.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-instructions.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-attention-check.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-single-stim.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-categorize.js",
-      "static/js/jspsych/plugins/jspsych-survey-text.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-stop-signal.js",
-      "static/css/jspsych.css",
-      "static/css/default_style.css",
-      "style.css",
-      "experiment.js"
-    ],
-    "exp_id": "smoking_followup_survey__stanford",
-    "contributors": [
-      "Jamie Li",
-      "Ian Eisenberg",
-      "Patrick Bissett",
-      "Zeynep Enkavi",
-      "Sadiv Parikh",
-      "Russell Poldrack"
-    ],
-    "time": 30,
-    "reference": "http://psycnet.apa.org/journals/xlm/37/2/392/",
-    "notes": "Condition refers to whether the trial is practice or high_freq/low_freq (the two test conditions) as well as whether it was a go or SS trial",
-    "publish": "True",
-    "experiment_variables": [
-      {
-        "name": "credit_var",
-        "type": "credit",
-        "datatype": "boolean",
-        "description": "True if avg_rt > 200"
-      }
-    ],
-    "deployment_variables": {
-      "jspsych_init": {
-        "fullscreen": true,
-        "display_element": "getDisplayElement",
-        "on_trial_finish": "addID()"
-      }
-    }
-  }
+    {
+        "name": "Smoking Follow-up Survey (Stanford)",
+        "template":"jspsych",
+        "run": [
+
+                "static/js/jspsych/jspsych.js",
+                "static/js/jspsych/plugins/jspsych-call-function.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-text.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-instructions.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-attention-check.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-single-stim.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-categorize.js",
+                "static/js/jspsych/plugins/jspsych-survey-text.js", 
+                "static/js/jspsych/poldrack_plugins/jspsych-stop-signal.js",
+                "static/css/jspsych.css",
+                "static/css/default_style.css",
+                "style.css",
+                "experiment.js"
+                
+                
+               ],
+        "exp_id": "smoking_followup_survey__stanford",
+        "cognitive_atlas_task_id": "tsk_4a57abb949e1a",
+        "contributors": [
+                         "Jamie Li",
+                         "Ian Eisenberg",
+                         "Patrick Bissett",
+                         "Zeynep Enkavi",
+                         "Sadiv Parikh",
+                         "Russell Poldrack"
+                        ], 
+        "time":30,
+        "reference": "http://psycnet.apa.org/journals/xlm/37/2/392/",
+        "notes": "Condition refers to whether the trial is practice or high_freq/low_freq (the two test conditions) as well as whether it was a go or SS trial",
+        "publish":"True",
+        "experiment_variables": [{
+                                 "name":"credit_var",
+                                 "type":"credit",
+                                 "datatype": "boolean",
+                                 "description":"True if avg_rt > 200"
+                                  }],
+        "deployment_variables":{"jspsych_init":
+                                        {"fullscreen": true,
+                                        "display_element": "getDisplayElement",
+                                        "on_trial_finish": "addID()"}
+                       			} 
+    
+   }
 ]
+

--- a/stop_signal_with_directed_forgetting/config.json
+++ b/stop_signal_with_directed_forgetting/config.json
@@ -1,49 +1,48 @@
 [
-  {
-    "name": "Stop Signal with Directed Forgetting",
-    "template": "jspsych",
-    "run": [
-      "static/js/math.min.js",
-      "static/js/jspsych/jspsych.js",
-      "static/js/jspsych/plugins/jspsych-text.js",
-      "static/js/jspsych/plugins/jspsych-call-function.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-text.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-instructions.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-single-stim.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-categorize.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-stop-signal.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-attention-check.js",
-      "static/js/jspsych/plugins/jspsych-survey-text.js",
-      "static/js/utils/poldrack_utils.js",
-      "experiment.js",
-      "static/css/jspsych.css",
-      "static/css/default_style.css",
-      "style.css"
-    ],
-    "exp_id": "stop_signal_with_directed_forgetting",
-    "contributors": [
-      "Jamie Li",
-      "Ian Eisenberg",
-      "Patrick Bissett",
-      "Russell Poldrack"
-    ],
-    "time": 20,
-    "reference": "http://psycnet.apa.org/psycarticles/2013-29647-001",
-    "publish": "True",
-    "experiment_variables": [
-      {
-        "name": "credit_var",
-        "type": "credit",
-        "datatype": "boolean",
-        "description": "True if avg_rt > 200"
-      }
-    ],
-    "deployment_variables": {
-      "jspsych_init": {
-        "fullscreen": true,
-        "display_element": "getDisplayElement",
-        "on_trial_finish": "addID('stop_signal_with_directed_forgetting')"
-      }
-    }
-  }
+    {
+        "name": "Stop Signal with Directed Forgetting",
+        "template":"jspsych",
+        "run": [
+                "static/js/math.min.js",
+                "static/js/jspsych/jspsych.js",
+                "static/js/jspsych/plugins/jspsych-text.js",
+                "static/js/jspsych/plugins/jspsych-call-function.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-text.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-instructions.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-single-stim.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-categorize.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-stop-signal.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-attention-check.js",
+                "static/js/jspsych/plugins/jspsych-survey-text.js",
+                "static/js/utils/poldrack_utils.js",
+                "experiment.js",
+                "static/css/jspsych.css",
+                "static/css/default_style.css",
+                "style.css"
+               ],
+        "exp_id": "stop_signal_with_directed_forgetting",
+        "cognitive_atlas_task_id": "trm_4f241ee9c4e37",
+        "contributors": [
+                         "Jamie Li",
+                         "Ian Eisenberg",
+                         "Patrick Bissett",
+                         "Russell Poldrack"
+                        ], 
+        "time":20,
+        "reference": "http://psycnet.apa.org/psycarticles/2013-29647-001",
+        "publish":"True",
+        "experiment_variables": [{
+                                 "name":"credit_var",
+                                 "type":"credit",
+                                 "datatype": "boolean",
+                                 "description":"True if avg_rt > 200"
+                                  }],
+        "deployment_variables":{"jspsych_init":
+                                        {"fullscreen": true,
+                                        "display_element": "getDisplayElement",
+                                        "on_trial_finish": "addID('stop_signal_with_directed_forgetting')"}
+                       }
+    
+   }
 ]
+

--- a/stop_signal_with_flanker/config.json
+++ b/stop_signal_with_flanker/config.json
@@ -1,49 +1,48 @@
 [
-  {
-    "name": "Stop Signal with Flanker",
-    "template": "jspsych",
-    "run": [
-      "static/js/math.min.js",
-      "static/js/jspsych/jspsych.js",
-      "static/js/jspsych/plugins/jspsych-text.js",
-      "static/js/jspsych/plugins/jspsych-call-function.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-text.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-instructions.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-single-stim.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-categorize.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-stop-signal.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-attention-check.js",
-      "static/js/jspsych/plugins/jspsych-survey-text.js",
-      "static/js/utils/poldrack_utils.js",
-      "experiment.js",
-      "static/css/jspsych.css",
-      "static/css/default_style.css",
-      "style.css"
-    ],
-    "exp_id": "stop_signal_with_flanker",
-    "contributors": [
-      "Patrick Bissett",
-      "Jamie Li",
-      "McKenzie Hagen",
-      "Russell Poldrack"
-    ],
-    "time": 20,
-    "reference": "http://psycnet.apa.org/psycarticles/2013-29647-001",
-    "publish": "True",
-    "experiment_variables": [
-      {
-        "name": "credit_var",
-        "type": "credit",
-        "datatype": "boolean",
-        "description": "True if avg_rt > 200"
-      }
-    ],
-    "deployment_variables": {
-      "jspsych_init": {
-        "fullscreen": true,
-        "display_element": "getDisplayElement",
-        "on_trial_finish": "addID('stop_signal_with_flanker')"
-      }
-    }
-  }
+    {
+        "name": "Stop Signal with Flanker",
+        "template":"jspsych",
+        "run": [
+                "static/js/math.min.js",
+                "static/js/jspsych/jspsych.js",
+                "static/js/jspsych/plugins/jspsych-text.js",
+                "static/js/jspsych/plugins/jspsych-call-function.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-text.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-instructions.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-single-stim.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-categorize.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-stop-signal.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-attention-check.js",
+                "static/js/jspsych/plugins/jspsych-survey-text.js",
+                "static/js/utils/poldrack_utils.js",
+                "experiment.js",
+                "static/css/jspsych.css",
+                "static/css/default_style.css",
+                "style.css"
+               ],
+        "exp_id": "stop_signal_with_flanker",
+        "cognitive_atlas_task_id": "trm_4f241ee9c4e37",
+        "contributors": [
+                         "Patrick Bissett",
+                         "Jamie Li",
+                         "McKenzie Hagen",
+                         "Russell Poldrack"
+                        ], 
+        "time":20,
+        "reference": "http://psycnet.apa.org/psycarticles/2013-29647-001",
+        "publish":"True",
+        "experiment_variables": [{
+                                 "name":"credit_var",
+                                 "type":"credit",
+                                 "datatype": "boolean",
+                                 "description":"True if avg_rt > 200"
+                                  }],
+        "deployment_variables":{"jspsych_init":
+                                        {"fullscreen": true,
+                                        "display_element": "getDisplayElement",
+                                        "on_trial_finish": "addID('stop_signal_with_flanker')"}
+                       }
+    
+   }
 ]
+

--- a/stop_signal_with_predictable_task_switching/config.json
+++ b/stop_signal_with_predictable_task_switching/config.json
@@ -1,49 +1,48 @@
 [
-  {
-    "name": "Stop Signal with Predictable Task Switching",
-    "template": "jspsych",
-    "run": [
-      "static/js/math.min.js",
-      "static/js/jspsych/jspsych.js",
-      "static/js/jspsych/plugins/jspsych-text.js",
-      "static/js/jspsych/plugins/jspsych-call-function.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-text.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-instructions.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-single-stim.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-categorize.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-stop-signal.js",
-      "static/js/jspsych/plugins/jspsych-survey-text.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-attention-check.js",
-      "static/js/utils/poldrack_utils.js",
-      "experiment.js",
-      "static/css/jspsych.css",
-      "static/css/default_style.css",
-      "style.css"
-    ],
-    "exp_id": "stop_signal_with_predictable_task_switching",
-    "contributors": [
-      "Jamie Li",
-      "Ian Eisenberg",
-      "Patrick Bissett",
-      "Russell Poldrack"
-    ],
-    "time": 20,
-    "reference": "http://psycnet.apa.org/psycarticles/2013-29647-001",
-    "publish": "True",
-    "experiment_variables": [
-      {
-        "name": "credit_var",
-        "type": "credit",
-        "datatype": "boolean",
-        "description": "True if avg_rt > 200"
-      }
-    ],
-    "deployment_variables": {
-      "jspsych_init": {
-        "fullscreen": true,
-        "display_element": "getDisplayElement",
-        "on_trial_finish": "addID('stop_signal_with_predictable_task_switching')"
-      }
-    }
-  }
+    {
+        "name": "Stop Signal with Predictable Task Switching",
+        "template":"jspsych",
+        "run": [
+                "static/js/math.min.js",
+                "static/js/jspsych/jspsych.js",
+                "static/js/jspsych/plugins/jspsych-text.js",
+                "static/js/jspsych/plugins/jspsych-call-function.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-text.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-instructions.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-single-stim.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-categorize.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-stop-signal.js",
+                "static/js/jspsych/plugins/jspsych-survey-text.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-attention-check.js",
+                "static/js/utils/poldrack_utils.js",
+                "experiment.js",
+                "static/css/jspsych.css",
+                "static/css/default_style.css",
+                "style.css"
+               ],
+        "exp_id": "stop_signal_with_predictable_task_switching",
+        "cognitive_atlas_task_id": "trm_4f241ee9c4e37",
+        "contributors": [
+                         "Jamie Li",
+                         "Ian Eisenberg",
+                         "Patrick Bissett",
+                         "Russell Poldrack"
+                        ], 
+        "time":20,
+        "reference": "http://psycnet.apa.org/psycarticles/2013-29647-001",
+        "publish":"True",
+        "experiment_variables": [{
+                                 "name":"credit_var",
+                                 "type":"credit",
+                                 "datatype": "boolean",
+                                 "description":"True if avg_rt > 200"
+                                  }],
+        "deployment_variables":{"jspsych_init":
+                                        {"fullscreen": true,
+                                        "display_element": "getDisplayElement",
+                                        "on_trial_finish": "addID('stop_signal_with_predictable_task_switching')"}
+                       }
+    
+   }
 ]
+

--- a/stop_signal_with_shape_matching/config.json
+++ b/stop_signal_with_shape_matching/config.json
@@ -1,49 +1,48 @@
 [
-  {
-    "name": "Stop Signal with Shape Matching",
-    "template": "jspsych",
-    "run": [
-      "static/js/math.min.js",
-      "static/js/jspsych/jspsych.js",
-      "static/js/jspsych/plugins/jspsych-text.js",
-      "static/js/jspsych/plugins/jspsych-call-function.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-text.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-instructions.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-single-stim.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-categorize.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-stop-signal.js",
-      "static/js/jspsych/plugins/jspsych-survey-text.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-attention-check.js",
-      "static/js/utils/poldrack_utils.js",
-      "experiment.js",
-      "static/css/jspsych.css",
-      "static/css/default_style.css",
-      "style.css"
-    ],
-    "exp_id": "stop_signal_with_shape_matching",
-    "contributors": [
-      "Jamie Li",
-      "Ian Eisenberg",
-      "Patrick Bissett",
-      "Russell Poldrack"
-    ],
-    "time": 20,
-    "reference": "http://psycnet.apa.org/psycarticles/2013-29647-001",
-    "publish": "True",
-    "experiment_variables": [
-      {
-        "name": "credit_var",
-        "type": "credit",
-        "datatype": "boolean",
-        "description": "True if avg_rt > 200"
-      }
-    ],
-    "deployment_variables": {
-      "jspsych_init": {
-        "fullscreen": true,
-        "display_element": "getDisplayElement",
-        "on_trial_finish": "addID('stop_signal_with_shape_matching')"
-      }
-    }
-  }
+    {
+        "name": "Stop Signal with Shape Matching",
+        "template":"jspsych",
+        "run": [
+                "static/js/math.min.js",
+                "static/js/jspsych/jspsych.js",
+                "static/js/jspsych/plugins/jspsych-text.js",
+                "static/js/jspsych/plugins/jspsych-call-function.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-text.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-instructions.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-single-stim.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-categorize.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-stop-signal.js",
+                "static/js/jspsych/plugins/jspsych-survey-text.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-attention-check.js",
+                "static/js/utils/poldrack_utils.js",
+                "experiment.js",
+                "static/css/jspsych.css",
+                "static/css/default_style.css",
+                "style.css"
+               ],
+        "exp_id": "stop_signal_with_shape_matching",
+        "cognitive_atlas_task_id": "trm_4f241ee9c4e37",
+        "contributors": [
+                         "Jamie Li",
+                         "Ian Eisenberg",
+                         "Patrick Bissett",
+                         "Russell Poldrack"
+                        ], 
+        "time":20,
+        "reference": "http://psycnet.apa.org/psycarticles/2013-29647-001",
+        "publish":"True",
+        "experiment_variables": [{
+                                 "name":"credit_var",
+                                 "type":"credit",
+                                 "datatype": "boolean",
+                                 "description":"True if avg_rt > 200"
+                                  }],
+        "deployment_variables":{"jspsych_init":
+                                        {"fullscreen": true,
+                                        "display_element": "getDisplayElement",
+                                        "on_trial_finish": "addID('stop_signal_with_shape_matching')"}
+                       }
+    
+   }
 ]
+

--- a/test_attn_check/config.json
+++ b/test_attn_check/config.json
@@ -1,57 +1,51 @@
 [
-  {
-    "name": "Test Attention Checks Task",
-    "template": "jspsych",
-    "run": [
-      "static/js/math.min.js",
-      "static/js/jspsych/jspsych.js",
-      "static/js/jspsych/plugins/jspsych-text.js",
-      "static/js/jspsych/plugins/jspsych-call-function.js",
-      "static/js/jspsych/plugins/jspsych-survey-text.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-text.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-attention-check.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-single-stim.js",
-      "static/js/utils/poldrack_utils.js",
-      "experiment.js",
-      "static/css/jspsych.css",
-      "static/css/default_style.css",
-      "style.css"
-    ],
-    "exp_id": "test_attn_check",
-    "contributors": [
-      "Ian Eisenberg",
-      "Zeynep Enkavi",
-      "Patrick Bissett",
-      "Vanessa Sochat",
-      "Russell Poldrack"
-    ],
-    "time": 1,
-    "experiment_variables": [
-      {
-        "name": "performance_var",
-        "type": "bonus",
-        "datatype": "numeric",
-        "range": [
-          0,
-          1000
-        ],
-        "description": "Faster responses get higher values"
-      },
-      {
-        "name": "credit_var",
-        "type": "credit",
-        "datatype": "boolean",
-        "description": "True if avg_rt > 200"
-      }
-    ],
-    "reference": "http://www.sciencedirect.com/science/article/pii/0001691869900651",
-    "publish": "True",
-    "deployment_variables": {
-      "jspsych_init": {
-        "fullscreen": true,
-        "display_element": "getDisplayElement",
-        "on_trial_finish": "addID('test_attn_check')"
-      }
-    }
-  }
+    {
+        "name": "Test Attention Checks Task",
+        "template":"jspsych",
+        "run": [
+                "static/js/math.min.js",
+                "static/js/jspsych/jspsych.js",
+                "static/js/jspsych/plugins/jspsych-text.js",
+                "static/js/jspsych/plugins/jspsych-call-function.js",
+                "static/js/jspsych/plugins/jspsych-survey-text.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-text.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-attention-check.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-single-stim.js",
+                "static/js/utils/poldrack_utils.js",
+                "experiment.js",
+                "static/css/jspsych.css",
+                "static/css/default_style.css",
+                "style.css"
+               ],
+        "exp_id": "test_attn_check",
+        "cognitive_atlas_task_id": "tsk_4a57abb949dc8",
+        "contributors": [
+                         "Ian Eisenberg",
+                         "Zeynep Enkavi",
+                         "Patrick Bissett",
+                         "Vanessa Sochat",
+                         "Russell Poldrack"
+                        ], 
+        "time":1,
+        "experiment_variables": [{
+                                 "name":"performance_var",
+                                 "type":"bonus",
+                                 "datatype": "numeric",
+                                 "range": [0,1000],
+                                 "description":"Faster responses get higher values"
+                                  },
+                                  {
+                                 "name":"credit_var",
+                                 "type":"credit",
+                                 "datatype": "boolean",
+                                 "description":"True if avg_rt > 200"
+                                  }],
+        "reference": "http://www.sciencedirect.com/science/article/pii/0001691869900651",
+        "publish":"True",
+        "deployment_variables":{"jspsych_init":
+                                        {"fullscreen": true,
+                                        "display_element": "getDisplayElement",
+                                        "on_trial_finish": "addID('test_attn_check')"}
+                       }
+   }
 ]

--- a/test_browser_chrome/config.json
+++ b/test_browser_chrome/config.json
@@ -1,49 +1,49 @@
 [
-  {
-    "name": "Test Browser Chrome",
-    "template": "jspsych",
-    "run": [
-      "static/js/math.min.js",
-      "static/js/jspsych/jspsych.js",
-      "static/js/jspsych/plugins/jspsych-call-function.js",
-      "static/js/jspsych/plugins/jspsych-text.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-text.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-instructions.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-attention-check.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-single-stim.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-categorize.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-stop-signal.js",
-      "static/js/jspsych/plugins/jspsych-survey-text.js",
-      "experiment.js",
-      "static/css/jspsych.css",
-      "static/css/default_style.css",
-      "style.css"
-    ],
-    "exp_id": "test_browser_chrome",
-    "contributors": [
-      "Patrick Bissett",
-      "Jamie Li",
-      "McKenzie Hagen",
-      "Russell Poldrack"
-    ],
-    "time": 30,
-    "reference": "http://psycnet.apa.org/journals/xlm/37/2/392/",
-    "notes": "Condition refers to whether the trial is practice or high_freq/low_freq (the two test conditions) as well as whether it was a go or SS trial",
-    "publish": "True",
-    "experiment_variables": [
-      {
-        "name": "credit_var",
-        "type": "credit",
-        "datatype": "boolean",
-        "description": "True if avg_rt > 200"
-      }
-    ],
-    "deployment_variables": {
-      "jspsych_init": {
-        "fullscreen": true,
-        "display_element": "getDisplayElement",
-        "on_trial_finish": "addID('stop_signal_single_task_network')"
-      }
-    }
-  }
+    {
+        "name": "Test Browser Chrome",
+        "template":"jspsych",
+        "run": [
+        		"static/js/math.min.js",
+                "static/js/jspsych/jspsych.js",
+                "static/js/jspsych/plugins/jspsych-call-function.js",
+                "static/js/jspsych/plugins/jspsych-text.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-text.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-instructions.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-attention-check.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-single-stim.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-categorize.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-stop-signal.js",
+                "static/js/jspsych/plugins/jspsych-survey-text.js", 
+                "experiment.js",
+                "static/css/jspsych.css",
+                "static/css/default_style.css",
+                "style.css"
+                
+
+               ],
+        "exp_id": "test_browser_chrome",
+        "cognitive_atlas_task_id": "tsk_4a57abb949e1a",
+        "contributors": [
+                         "Patrick Bissett",
+                         "Jamie Li",
+                         "McKenzie Hagen",
+                         "Russell Poldrack"
+                        ], 
+        "time":30,
+        "reference": "http://psycnet.apa.org/journals/xlm/37/2/392/",
+        "notes": "Condition refers to whether the trial is practice or high_freq/low_freq (the two test conditions) as well as whether it was a go or SS trial",
+        "publish":"True",
+        "experiment_variables": [{
+                                 "name":"credit_var",
+                                 "type":"credit",
+                                 "datatype": "boolean",
+                                 "description":"True if avg_rt > 200"
+                                  }],
+        "deployment_variables":{"jspsych_init":
+                                        {"fullscreen": true,
+                                        "display_element": "getDisplayElement",
+                                        "on_trial_finish": "addID('stop_signal_single_task_network')"}
+                       			} 
+    
+   }
 ]

--- a/test_task/config.json
+++ b/test_task/config.json
@@ -1,57 +1,51 @@
 [
-  {
-    "name": "Test Task",
-    "template": "jspsych",
-    "run": [
-      "static/js/math.min.js",
-      "static/js/jspsych/jspsych.js",
-      "static/js/jspsych/plugins/jspsych-text.js",
-      "static/js/jspsych/plugins/jspsych-call-function.js",
-      "static/js/jspsych/plugins/jspsych-survey-text.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-text.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-attention-check.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-single-stim.js",
-      "static/js/utils/poldrack_utils.js",
-      "experiment.js",
-      "static/css/jspsych.css",
-      "static/css/default_style.css",
-      "style.css"
-    ],
-    "exp_id": "test_task",
-    "contributors": [
-      "Ian Eisenberg",
-      "Zeynep Enkavi",
-      "Patrick Bissett",
-      "Vanessa Sochat",
-      "Russell Poldrack"
-    ],
-    "time": 1,
-    "experiment_variables": [
-      {
-        "name": "performance_var",
-        "type": "bonus",
-        "datatype": "numeric",
-        "range": [
-          0,
-          1000
-        ],
-        "description": "Faster responses get higher values"
-      },
-      {
-        "name": "credit_var",
-        "type": "credit",
-        "datatype": "boolean",
-        "description": "True if avg_rt > 200"
-      }
-    ],
-    "reference": "http://www.sciencedirect.com/science/article/pii/0001691869900651",
-    "publish": "True",
-    "deployment_variables": {
-      "jspsych_init": {
-        "fullscreen": true,
-        "display_element": "getDisplayElement",
-        "on_trial_finish": "addID('test_task')"
-      }
-    }
-  }
+    {
+        "name": "Test Task",
+        "template":"jspsych",
+        "run": [
+                "static/js/math.min.js",
+                "static/js/jspsych/jspsych.js",
+                "static/js/jspsych/plugins/jspsych-text.js",
+                "static/js/jspsych/plugins/jspsych-call-function.js",
+                "static/js/jspsych/plugins/jspsych-survey-text.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-text.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-attention-check.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-single-stim.js",
+                "static/js/utils/poldrack_utils.js",
+                "experiment.js",
+                "static/css/jspsych.css",
+                "static/css/default_style.css",
+                "style.css"
+               ],
+        "exp_id": "test_task",
+        "cognitive_atlas_task_id": "tsk_4a57abb949dc8",
+        "contributors": [
+                         "Ian Eisenberg",
+                         "Zeynep Enkavi",
+                         "Patrick Bissett",
+                         "Vanessa Sochat",
+                         "Russell Poldrack"
+                        ], 
+        "time":1,
+        "experiment_variables": [{
+                                 "name":"performance_var",
+                                 "type":"bonus",
+                                 "datatype": "numeric",
+                                 "range": [0,1000],
+                                 "description":"Faster responses get higher values"
+                                  },
+                                  {
+                                 "name":"credit_var",
+                                 "type":"credit",
+                                 "datatype": "boolean",
+                                 "description":"True if avg_rt > 200"
+                                  }],
+        "reference": "http://www.sciencedirect.com/science/article/pii/0001691869900651",
+        "publish":"True",
+        "deployment_variables":{"jspsych_init":
+                                        {"fullscreen": true,
+                                        "display_element": "getDisplayElement",
+                                        "on_trial_finish": "addID('test_task')"}
+                       }
+   }
 ]

--- a/test_task_always_fail/config.json
+++ b/test_task_always_fail/config.json
@@ -1,57 +1,51 @@
 [
-  {
-    "name": "Test Task Always Fail",
-    "template": "jspsych",
-    "run": [
-      "static/js/math.min.js",
-      "static/js/jspsych/jspsych.js",
-      "static/js/jspsych/plugins/jspsych-text.js",
-      "static/js/jspsych/plugins/jspsych-call-function.js",
-      "static/js/jspsych/plugins/jspsych-survey-text.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-text.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-attention-check.js",
-      "static/js/jspsych/poldrack_plugins/jspsych-poldrack-single-stim.js",
-      "static/js/utils/poldrack_utils.js",
-      "experiment.js",
-      "static/css/jspsych.css",
-      "static/css/default_style.css",
-      "style.css"
-    ],
-    "exp_id": "test_task_always_fail",
-    "contributors": [
-      "Ian Eisenberg",
-      "Zeynep Enkavi",
-      "Patrick Bissett",
-      "Vanessa Sochat",
-      "Russell Poldrack"
-    ],
-    "time": 1,
-    "experiment_variables": [
-      {
-        "name": "performance_var",
-        "type": "bonus",
-        "datatype": "numeric",
-        "range": [
-          0,
-          1000
-        ],
-        "description": "Faster responses get higher values"
-      },
-      {
-        "name": "credit_var",
-        "type": "credit",
-        "datatype": "boolean",
-        "description": "True if avg_rt > 200"
-      }
-    ],
-    "reference": "http://www.sciencedirect.com/science/article/pii/0001691869900651",
-    "publish": "True",
-    "deployment_variables": {
-      "jspsych_init": {
-        "fullscreen": true,
-        "display_element": "getDisplayElement",
-        "on_trial_finish": "addID('test_task_always_fail')"
-      }
-    }
-  }
+    {
+        "name": "Test Task Always Fail",
+        "template":"jspsych",
+        "run": [
+                "static/js/math.min.js",
+                "static/js/jspsych/jspsych.js",
+                "static/js/jspsych/plugins/jspsych-text.js",
+                "static/js/jspsych/plugins/jspsych-call-function.js",
+                "static/js/jspsych/plugins/jspsych-survey-text.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-text.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-attention-check.js",
+                "static/js/jspsych/poldrack_plugins/jspsych-poldrack-single-stim.js",
+                "static/js/utils/poldrack_utils.js",
+                "experiment.js",
+                "static/css/jspsych.css",
+                "static/css/default_style.css",
+                "style.css"
+               ],
+        "exp_id": "test_task_always_fail",
+        "cognitive_atlas_task_id": "tsk_4a57abb949dc8",
+        "contributors": [
+                         "Ian Eisenberg",
+                         "Zeynep Enkavi",
+                         "Patrick Bissett",
+                         "Vanessa Sochat",
+                         "Russell Poldrack"
+                        ], 
+        "time":1,
+        "experiment_variables": [{
+                                 "name":"performance_var",
+                                 "type":"bonus",
+                                 "datatype": "numeric",
+                                 "range": [0,1000],
+                                 "description":"Faster responses get higher values"
+                                  },
+                                  {
+                                 "name":"credit_var",
+                                 "type":"credit",
+                                 "datatype": "boolean",
+                                 "description":"True if avg_rt > 200"
+                                  }],
+        "reference": "http://www.sciencedirect.com/science/article/pii/0001691869900651",
+        "publish":"True",
+        "deployment_variables":{"jspsych_init":
+                                        {"fullscreen": true,
+                                        "display_element": "getDisplayElement",
+                                        "on_trial_finish": "addID('test_task_always_fail')"}
+                       }
+   }
 ]


### PR DESCRIPTION
Reverts expfactory/expfactory-experiments#604

forgot current version of expfactory-python expects field to be there but with empty string.